### PR TITLE
Apply source formatting baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,11 @@
-*.h         eol=crlf
-*.hpp       eol=crlf
-*.cpp       eol=crlf
-*.c         eol=crlf
-*.rc        eol=crlf
-*.vcproj    eol=crlf
-*.bat       eol=crlf
-*.sln       eol=crlf
+*.h         text eol=crlf
+*.hpp       text eol=crlf
+*.c         text eol=crlf
+*.cc        text eol=crlf
+*.cpp       text eol=crlf
+*.cxx       text eol=crlf
+*.rc        text eol=crlf
+*.vcproj    text eol=crlf
+*.bat       text eol=crlf
+*.sln       text eol=crlf
 *.ico -text

--- a/docs/CODE-STYLE.md
+++ b/docs/CODE-STYLE.md
@@ -1,0 +1,41 @@
+# OpenVSM C and C++ style
+
+OpenVSM's project-owned C and C++ sources are formatted with the repository's
+`.clang-format` file. The current baseline is clang-format 21.
+
+## Scope
+
+Formatting applies to C and C++ files under `model/cpp` and `model/include`,
+except for code maintained outside this project:
+
+- Git submodules, including `model/cpp/log` and `externals/Lua`;
+- the locally supplied Proteus SDK under `externals/sdk`;
+- the third-party single-header library `model/include/incbin.h`.
+
+Lua, CMake, PowerShell, project data, and generated files are outside the
+clang-format scope.
+
+## Running the formatter
+
+From the repository root in PowerShell, format all in-scope files with:
+
+```powershell
+./tools/format.ps1
+```
+
+Check formatting without changing files with:
+
+```powershell
+./tools/format.ps1 -Check
+```
+
+## Main rules
+
+- Use four spaces and never tabs.
+- Keep lines at or below 120 columns where clang-format can do so.
+- Use Allman braces.
+- Always brace control-statement bodies.
+- Preserve include order; include sorting is intentionally disabled.
+
+Formatting-only changes must be kept separate from behavioral changes so that
+reviews and history remain readable.

--- a/model/cpp/dllmain.cc
+++ b/model/cpp/dllmain.cc
@@ -7,52 +7,52 @@
 
 namespace
 {
-  bool vsmRegister(ILICENCESERVER *ils)
-  {
+bool vsmRegister(ILICENCESERVER *ils)
+{
     if (!ils->authorize(0, VSM_API_VERSION))
     {
-      return false;
+        return false;
     }
     return true;
-  }
 }
+} // namespace
 
 extern "C"
 {
-  IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
-  {
-    (void)device;
-    vsmRegister(ils);
-    return new DeviceSimulator::VirtualDevice;
-  }
+    IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
+    {
+        (void)device;
+        vsmRegister(ils);
+        return new DeviceSimulator::VirtualDevice;
+    }
 
-  void __declspec(dllexport) deletedsimmodel(IDSIMMODEL *model)
-  {
-    delete model;
-  }
+    void __declspec(dllexport) deletedsimmodel(IDSIMMODEL *model)
+    {
+        delete model;
+    }
 }
 
 bool APIENTRY DllMain(HINSTANCE hInstDLL, uint32_t fdwReason, LPVOID lpvReserved)
 {
-  switch (fdwReason)
-  {
-  case DLL_PROCESS_ATTACH:
-    Log::get().configure(TraceType::file);
-    Log::get().set_level(TraceSeverity::debug);
-    LOG_DEBUG("The model is being loaded\n");
-    break;
-  case DLL_PROCESS_DETACH:
-    LOG_DEBUG("The model is being unloaded\n");
-    break;
-  case DLL_THREAD_ATTACH:
-    LOG_DEBUG("A thread is being created\n");
-    break;
-  case DLL_THREAD_DETACH:
-    LOG_DEBUG("A thread is being destroyed\n");
-    break;
-  }
-  (void)hInstDLL;
-  (void)fdwReason;
-  (void)lpvReserved;
-  return true;
+    switch (fdwReason)
+    {
+    case DLL_PROCESS_ATTACH:
+        Log::get().configure(TraceType::file);
+        Log::get().set_level(TraceSeverity::debug);
+        LOG_DEBUG("The model is being loaded\n");
+        break;
+    case DLL_PROCESS_DETACH:
+        LOG_DEBUG("The model is being unloaded\n");
+        break;
+    case DLL_THREAD_ATTACH:
+        LOG_DEBUG("A thread is being created\n");
+        break;
+    case DLL_THREAD_DETACH:
+        LOG_DEBUG("A thread is being destroyed\n");
+        break;
+    }
+    (void)hInstDLL;
+    (void)fdwReason;
+    (void)lpvReserved;
+    return true;
 }

--- a/model/cpp/luabind/bytecode_loader.cc
+++ b/model/cpp/luabind/bytecode_loader.cc
@@ -5,40 +5,40 @@
 
 namespace LuaScripting
 {
-  std::string loadBytecodeFromResource(const std::string &resourceName)
-  {
+std::string loadBytecodeFromResource(const std::string &resourceName)
+{
     auto it = resourceMap.find(resourceName);
     if (it != resourceMap.end())
     {
-      return std::string(it->second.data, it->second.size);
+        return std::string(it->second.data, it->second.size);
     }
     LOG_DEBUG("Resource {} not found in map\n", resourceName);
     return std::string();
-  }
+}
 
-  bool preloadModule(lua_State *L, const std::string &moduleName)
-  {
+bool preloadModule(lua_State *L, const std::string &moduleName)
+{
     bool result = false;
     std::string code = loadBytecodeFromResource(moduleName);
     if (code.empty())
     {
-      LOG_DEBUG("Could not load bytecode of {} from resources\n", moduleName);
-      return result;
+        LOG_DEBUG("Could not load bytecode of {} from resources\n", moduleName);
+        return result;
     }
     lua_getglobal(L, "package");
     lua_getfield(L, -1, "preload");
     if (luaL_loadbuffer(L, code.c_str(), code.size(), moduleName.c_str()) == 0)
     {
-      lua_setfield(L, -2, moduleName.c_str());
-      result = true;
+        lua_setfield(L, -2, moduleName.c_str());
+        result = true;
     }
     else
     {
-      LOG_DEBUG("Error preloading module {}: {}\n", moduleName, lua_tostring(L, -1));
-      lua_pop(L, 1);
+        LOG_DEBUG("Error preloading module {}: {}\n", moduleName, lua_tostring(L, -1));
+        lua_pop(L, 1);
     }
 
     lua_pop(L, 2);
     return result;
-  }
 }
+} // namespace LuaScripting

--- a/model/cpp/luabind/device/pin.cc
+++ b/model/cpp/luabind/device/pin.cc
@@ -4,13 +4,13 @@
 
 namespace DeviceSimulator
 {
-  model_pin getPinSelf(lua_State *L)
-  {
+model_pin getPinSelf(lua_State *L)
+{
     if (!lua_istable(L, -lua_gettop(L)))
     {
-      LOG_DEBUG("Error: not a table\n");
-      lua_pop(L, 1); // Pop the invalid value from the stack
-      return model_pin{};
+        LOG_DEBUG("Error: not a table\n");
+        lua_pop(L, 1); // Pop the invalid value from the stack
+        return model_pin{};
     }
 
     lua_pushstring(L, "pinName");
@@ -28,10 +28,10 @@ namespace DeviceSimulator
     pin.on_time = 0;
     pin.off_time = 0;
     return pin;
-  }
+}
 
-  static int l_pin_set(lua_State *L)
-  {
+static int l_pin_set(lua_State *L)
+{
     auto pin = getPinSelf(L);
 
     int level = luaL_checkinteger(L, -1);
@@ -45,10 +45,10 @@ namespace DeviceSimulator
     dsim->sysvar(&at, DSIMTIMENOW);
     pinInstance->setstate(at, 10000, level == 1 ? TSTATE : FSTATE);
     return 0;
-  }
+}
 
-  static int l_pin_set_state(lua_State *L)
-  {
+static int l_pin_set_state(lua_State *L)
+{
     auto pin = getPinSelf(L);
 
     STATE state = (STATE)luaL_checkinteger(L, -1);
@@ -62,10 +62,10 @@ namespace DeviceSimulator
     dsim->sysvar(&at, DSIMTIMENOW);
     pinInstance->setstate(at, 10000, state);
     return 0;
-  }
+}
 
-  static int l_pin_get(lua_State *L)
-  {
+static int l_pin_get(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
@@ -73,193 +73,192 @@ namespace DeviceSimulator
     auto state = pinInstance->istate();
     lua_pushinteger(L, ishigh(state) ? 1 : 0);
     return 1;
-  }
+}
 
-  static int l_pin_set_hi(lua_State *L)
-  {
+static int l_pin_set_hi(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     pinInstance->setstate(TSTATE);
     return 0;
-  }
+}
 
-  static int l_pin_set_lo(lua_State *L)
-  {
+static int l_pin_set_lo(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     pinInstance->setstate(FSTATE);
     return 0;
-  }
+}
 
-  static int l_pin_invert(lua_State *L)
-  {
+static int l_pin_invert(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     pinInstance->invert();
     return 0;
-  }
+}
 
-  static int l_pint_issteady(lua_State *L)
-  {
+static int l_pint_issteady(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->issteady());
     return 1;
-  }
+}
 
-  static int l_pin_activity(lua_State *L)
-  {
+static int l_pin_activity(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushinteger(L, pinInstance->activity());
     return 1;
-  }
+}
 
-  static int l_pin_isactive(lua_State *L)
-  {
+static int l_pin_isactive(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->isactive());
     return 1;
-  }
+}
 
-  static int l_pin_isinactive(lua_State *L)
-  {
+static int l_pin_isinactive(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->isinactive());
     return 1;
-  }
+}
 
-  static int l_pin_isposedge(lua_State *L)
-  {
+static int l_pin_isposedge(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->isposedge());
     return 1;
-  }
+}
 
-  static int l_pin_isnegedge(lua_State *L)
-  {
+static int l_pin_isnegedge(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->isnegedge());
     return 1;
-  }
+}
 
-  static int l_pin_isedge(lua_State *L)
-  {
+static int l_pin_isedge(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     lua_pushboolean(L, pinInstance->isedge());
     return 1;
-  }
+}
 
-  static int l_pin_islow(lua_State *L)
-  {
+static int l_pin_islow(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, islow(state));
     return 1;
-  }
+}
 
-  static int l_pin_ishigh(lua_State *L)
-  {
+static int l_pin_ishigh(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, ishigh(state));
     return 1;
-  }
+}
 
-  static int l_pin_isfloating(lua_State *L)
-  {
+static int l_pin_isfloating(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, isfloating(state));
     return 1;
-  }
+}
 
-  static int l_pin_iscontention(lua_State *L)
-  {
+static int l_pin_iscontention(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, iscontention(state));
     return 1;
-  }
+}
 
-  static int l_pin_isdefined(lua_State *L)
-  {
+static int l_pin_isdefined(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, isdefined(state));
     return 1;
-  }
+}
 
-  static int l_pin_ishighlow(lua_State *L)
-  {
+static int l_pin_ishighlow(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushboolean(L, ishighlow(state));
     return 1;
-  }
+}
 
-  static int l_pin_polarity(lua_State *L)
-  {
+static int l_pin_polarity(lua_State *L)
+{
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
     auto state = pinInstance->istate();
     lua_pushinteger(L, polarity(state));
     return 1;
-  }
+}
 
-  static const luaL_Reg VsmPinMethodsLib[] = {
-      {"set", l_pin_set},
-      {"setstate", l_pin_set_state},
-      {"get", l_pin_get},
-      {"hi", l_pin_set_hi},
-      {"lo", l_pin_set_lo},
-      {"invert", l_pin_invert},
-      {"issteady", l_pint_issteady},
-      {"activity", l_pin_activity},
-      {"isactive", l_pin_isactive},
-      {"isinactive", l_pin_isinactive},
-      {"isposedge", l_pin_isposedge},
-      {"isnegedge", l_pin_isnegedge},
-      {"isedge", l_pin_isedge},
-      {"islow", l_pin_islow},
-      {"ishigh", l_pin_ishigh},
-      {"isfloating", l_pin_isfloating},
-      {"iscontention", l_pin_iscontention},
-      {"isdefined", l_pin_isdefined},
-      {"ishighlow", l_pin_ishighlow},
-      {"polarity", l_pin_polarity},
-      {NULL, NULL}};
+static const luaL_Reg VsmPinMethodsLib[] = {{"set", l_pin_set},
+                                            {"setstate", l_pin_set_state},
+                                            {"get", l_pin_get},
+                                            {"hi", l_pin_set_hi},
+                                            {"lo", l_pin_set_lo},
+                                            {"invert", l_pin_invert},
+                                            {"issteady", l_pint_issteady},
+                                            {"activity", l_pin_activity},
+                                            {"isactive", l_pin_isactive},
+                                            {"isinactive", l_pin_isinactive},
+                                            {"isposedge", l_pin_isposedge},
+                                            {"isnegedge", l_pin_isnegedge},
+                                            {"isedge", l_pin_isedge},
+                                            {"islow", l_pin_islow},
+                                            {"ishigh", l_pin_ishigh},
+                                            {"isfloating", l_pin_isfloating},
+                                            {"iscontention", l_pin_iscontention},
+                                            {"isdefined", l_pin_isdefined},
+                                            {"ishighlow", l_pin_ishighlow},
+                                            {"polarity", l_pin_polarity},
+                                            {NULL, NULL}};
 
-  void VirtualDevice::registerPin(const char *name, int num)
-  {
+void VirtualDevice::registerPin(const char *name, int num)
+{
     LOG_DEBUG("Registering pin {}-{}\n", name, num);
     luaL_newlib(luactx_, VsmPinMethodsLib);
 
@@ -271,5 +270,5 @@ namespace DeviceSimulator
     lua_setfield(luactx_, -2, "pinName");
     // Set the library as a global variable with the given name
     lua_setglobal(luactx_, name);
-  }
 }
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/lua_bind.hpp
+++ b/model/cpp/luabind/lua_bind.hpp
@@ -11,43 +11,43 @@
 #define LTABLE (&lua_istable)
 #define LNONE (NULL)
 
-#define LUA_REGISTER_FUNCTION(ctx, funcName, cFunc) \
-  lua_pushcfunction(ctx, cFunc);                    \
-  lua_setglobal(ctx, funcName);
+#define LUA_REGISTER_FUNCTION(ctx, funcName, cFunc)                                                                    \
+    lua_pushcfunction(ctx, cFunc);                                                                                     \
+    lua_setglobal(ctx, funcName);
 
-#define LUA_REGISTER_METHOD(ctx, methodName, cFunc) \
-  lua_pushcfunction(ctx, cFunc);                    \
-  lua_setfield(ctx, -2, methodName);
+#define LUA_REGISTER_METHOD(ctx, methodName, cFunc)                                                                    \
+    lua_pushcfunction(ctx, cFunc);                                                                                     \
+    lua_setfield(ctx, -2, methodName);
 
 typedef struct
 {
-  const char *lua_func_name;
-  int (*lua_c_api)(lua_State *);
-  int (*args[16])(lua_State *, int index);
+    const char *lua_func_name;
+    int (*lua_c_api)(lua_State *);
+    int (*args[16])(lua_State *, int index);
 } luaBindFunc;
 
 namespace LuaScripting
 {
-  bool preloadModule(lua_State *L, const std::string &moduleName);
-  std::string loadBytecodeFromResource(const std::string &resourceName);
+bool preloadModule(lua_State *L, const std::string &moduleName);
+std::string loadBytecodeFromResource(const std::string &resourceName);
 
-  std::vector<char32_t> luaPopChar32Array(lua_State *L, int argPosition = 1);
-  std::u32string luaPopU32String(lua_State *L, int argPosition = 1);
-  std::string luaPopString(lua_State *L, int argPosition = 1);
-  int luaPushU32String(lua_State *L, const std::u32string &str);
-  int luaPushString(lua_State *L, const std::string &str);
-  int luaPushVectorInt(lua_State *L, const std::vector<uint32_t> &vec);
-  int luaPushVectorString32(lua_State *L, const std::vector<std::u32string> &vec);
-  int luaPushVectorString(lua_State *L, const std::vector<std::string> &vec);
-  int luaPushMapStringInt(lua_State *L, const std::map<std::string, int> &map);
+std::vector<char32_t> luaPopChar32Array(lua_State *L, int argPosition = 1);
+std::u32string luaPopU32String(lua_State *L, int argPosition = 1);
+std::string luaPopString(lua_State *L, int argPosition = 1);
+int luaPushU32String(lua_State *L, const std::u32string &str);
+int luaPushString(lua_State *L, const std::string &str);
+int luaPushVectorInt(lua_State *L, const std::vector<uint32_t> &vec);
+int luaPushVectorString32(lua_State *L, const std::vector<std::u32string> &vec);
+int luaPushVectorString(lua_State *L, const std::vector<std::string> &vec);
+int luaPushMapStringInt(lua_State *L, const std::map<std::string, int> &map);
 
-  void registerDictManagement(lua_State *ctx);
-  void registerKanaProcessor(lua_State *ctx);
-  void registerDictSearch(lua_State *ctx);
-  void registerKanjiSearch(lua_State *L);
-  void registerJlptSearch(lua_State *L);
-  void registerExamplesSearch(lua_State *L);
-  void registerKanjiVgSearch(lua_State *L);
+void registerDictManagement(lua_State *ctx);
+void registerKanaProcessor(lua_State *ctx);
+void registerDictSearch(lua_State *ctx);
+void registerKanjiSearch(lua_State *L);
+void registerJlptSearch(lua_State *L);
+void registerExamplesSearch(lua_State *L);
+void registerKanjiVgSearch(lua_State *L);
 
-  void registerUserNotes(lua_State *L);
-}
+void registerUserNotes(lua_State *L);
+} // namespace LuaScripting

--- a/model/cpp/luabind/lua_facade.cc
+++ b/model/cpp/luabind/lua_facade.cc
@@ -3,53 +3,53 @@
 #include "lua.hpp"
 namespace LuaScripting
 {
-  LuaTableFacade::LuaTableFacade(lua_State *ctx, const std::string &module)
-  {
-    LOG_DEBUG("Loading module {}\n", module);    
+LuaTableFacade::LuaTableFacade(lua_State *ctx, const std::string &module)
+{
+    LOG_DEBUG("Loading module {}\n", module);
     L_ = ctx;
-    if(!lua_getglobal(L_, "require"))
+    if (!lua_getglobal(L_, "require"))
     {
-      throw LuaException("Error requiring module: require not found");
+        throw LuaException("Error requiring module: require not found");
     }
     lua_pushstring(L_, module.c_str());
     if (lua_pcall(L_, 1, 1, 0) != 0)
     {
-      std::string error = lua_tostring(L_, -1);
-      lua_pop(L_, 1);
-      throw LuaException("Error requiring module: " + error);
+        std::string error = lua_tostring(L_, -1);
+        lua_pop(L_, 1);
+        throw LuaException("Error requiring module: " + error);
     }
     LOG_DEBUG("Module {} required successfully\n", module);
     tableRef_ = luaL_ref(L_, LUA_REGISTRYINDEX);
     if (!checkLuaTable(L_, tableRef_))
     {
-      LOG_DEBUG("Module {} is not a table\n", module);
-      throw LuaException("Error loading module: not a table");
+        LOG_DEBUG("Module {} is not a table\n", module);
+        throw LuaException("Error loading module: not a table");
     }
-    //LOG_DEBUG("Module {} loaded successfully\n", module);
-  }
+    // LOG_DEBUG("Module {} loaded successfully\n", module);
+}
 
-  LuaTableFacade::~LuaTableFacade()
-  {
+LuaTableFacade::~LuaTableFacade()
+{
     luaL_unref(L_, LUA_REGISTRYINDEX, tableRef_);
-  }
+}
 
-  void LuaTableFacade::newSelfInstance(int self)
-  {    
+void LuaTableFacade::newSelfInstance(int self)
+{
     if (!checkLuaTable(L_, self))
     {
-      std::string err = "Failed to create new instance: not a table.";
-      LOG_DEBUG("[LUA]: {}\n", err);
-      throw LuaException(err);
+        std::string err = "Failed to create new instance: not a table.";
+        LOG_DEBUG("[LUA]: {}\n", err);
+        throw LuaException(err);
     }
     luaL_unref(L_, LUA_REGISTRYINDEX, tableRef_);
     tableRef_ = self;
-  }
+}
 
-  bool LuaTableFacade::checkLuaTable(lua_State *L, int tableRef)
-  {
+bool LuaTableFacade::checkLuaTable(lua_State *L, int tableRef)
+{
     lua_rawgeti(L, LUA_REGISTRYINDEX, tableRef);
     bool isTable = lua_istable(L, -1);
     lua_pop(L, 1); // Remove the table (or non-table) from the stack
     return isTable;
-  }
 }
+} // namespace LuaScripting

--- a/model/cpp/luabind/lua_facade.hpp
+++ b/model/cpp/luabind/lua_facade.hpp
@@ -7,74 +7,72 @@
 #include <lua.hpp>
 #include <stdexcept>
 
-
 namespace LuaScripting
 {
-  class LuaException : public std::runtime_error
-  {
+class LuaException : public std::runtime_error
+{
   public:
-    LuaException(const std::string &message)
-        : std::runtime_error("LuaException: " + message) {}
-  };
-  
-  using TableReference = int;
-  class LuaTableFacade
-  {
-  public:   
+    LuaException(const std::string &message) : std::runtime_error("LuaException: " + message)
+    {
+    }
+};
 
-    LuaTableFacade(lua_State *ctx, const std::string &module);       
+using TableReference = int;
+class LuaTableFacade
+{
+  public:
+    LuaTableFacade(lua_State *ctx, const std::string &module);
     ~LuaTableFacade();
 
-    template <typename Ret, typename... Args>
-    Ret callMethod(const std::string &methodName, Args... args)
+    template <typename Ret, typename... Args> Ret callMethod(const std::string &methodName, Args... args)
     {
-      // Push the Lua table onto the stack using the stored reference
-      lua_rawgeti(L_, LUA_REGISTRYINDEX, tableRef_);
-      if (!lua_istable(L_, -1))
-      {
-        throw LuaException("Not a table");
-      }
-
-      // Push the method onto the stack
-      lua_getfield(L_, -1, methodName.c_str());
-      if (!lua_isfunction(L_, -1))
-      {
-        throw LuaException("Not a function");
-      }
-
-      lua_pushvalue(L_, -2);
-      (luaPushArgs(args), ...);
-      if (lua_pcall(L_, sizeof...(Args) + 1, 1, 0) != 0)
-      {
-        std::string message;
-        int errorType = lua_type(L_, -1);
-        switch (errorType)
+        // Push the Lua table onto the stack using the stored reference
+        lua_rawgeti(L_, LUA_REGISTRYINDEX, tableRef_);
+        if (!lua_istable(L_, -1))
         {
-        case LUA_TSTRING:
-          message = lua_tostring(L_, -1);
-          break;
-        case LUA_TTABLE:
-          break;
-        case LUA_TNUMBER:
-          message = "Error object is a number: " + std::to_string(lua_tonumber(L_, -1));
-          break;
-        case LUA_TBOOLEAN:
-          message = "Error object is a boolean: " + std::string(lua_toboolean(L_, -1) ? "true" : "false");
-          break;
-        default:
-          message = "Unknown error type: " + std::string(lua_typename(L_, errorType));
-          break;
+            throw LuaException("Not a table");
         }
 
-        luaL_traceback(L_, L_, message.c_str(), 1);
-        const char *traceback = lua_tostring(L_, -1);
-        std::string error = traceback ? traceback : "Error with no traceback";
-        lua_pop(L_, 2); // Pop error message and traceback
-        throw LuaException(error);
-      }
-      Ret returnValue = getReturnValue<Ret>(-1);
-      lua_pop(L_, 2);
-      return returnValue;
+        // Push the method onto the stack
+        lua_getfield(L_, -1, methodName.c_str());
+        if (!lua_isfunction(L_, -1))
+        {
+            throw LuaException("Not a function");
+        }
+
+        lua_pushvalue(L_, -2);
+        (luaPushArgs(args), ...);
+        if (lua_pcall(L_, sizeof...(Args) + 1, 1, 0) != 0)
+        {
+            std::string message;
+            int errorType = lua_type(L_, -1);
+            switch (errorType)
+            {
+            case LUA_TSTRING:
+                message = lua_tostring(L_, -1);
+                break;
+            case LUA_TTABLE:
+                break;
+            case LUA_TNUMBER:
+                message = "Error object is a number: " + std::to_string(lua_tonumber(L_, -1));
+                break;
+            case LUA_TBOOLEAN:
+                message = "Error object is a boolean: " + std::string(lua_toboolean(L_, -1) ? "true" : "false");
+                break;
+            default:
+                message = "Unknown error type: " + std::string(lua_typename(L_, errorType));
+                break;
+            }
+
+            luaL_traceback(L_, L_, message.c_str(), 1);
+            const char *traceback = lua_tostring(L_, -1);
+            std::string error = traceback ? traceback : "Error with no traceback";
+            lua_pop(L_, 2); // Pop error message and traceback
+            throw LuaException(error);
+        }
+        Ret returnValue = getReturnValue<Ret>(-1);
+        lua_pop(L_, 2);
+        return returnValue;
     }
 
     void newSelfInstance(int newReference);
@@ -83,103 +81,101 @@ namespace LuaScripting
     lua_State *L_;
     int tableRef_ = LUA_NOREF;
 
-    template <typename T>
-    void luaPushArgs(T value)
+    template <typename T> void luaPushArgs(T value)
     {
-      if constexpr (std::is_integral_v<T>)
-      {
-        lua_pushinteger(L_, static_cast<lua_Integer>(value));
-      }
-      else if constexpr (std::is_floating_point_v<T>)
-      {
-        lua_pushnumber(L_, static_cast<lua_Number>(value));
-      }
-      else if constexpr (std::is_same_v<T, const char *>)
-      {
-        lua_pushstring(L_, value);
-      }
-      else if constexpr (std::is_same_v<T, std::string>)
-      {
-        lua_pushstring(L_, value.c_str());
-      }
-      else
-      {
-        static_assert(std::is_integral_v<T> || std::is_floating_point_v<T> ||
-                          std::is_same_v<T, const char *> || std::is_same_v<T, std::string>,
-                      "Unsupported argument type for luaPushArgs");
-      }
+        if constexpr (std::is_integral_v<T>)
+        {
+            lua_pushinteger(L_, static_cast<lua_Integer>(value));
+        }
+        else if constexpr (std::is_floating_point_v<T>)
+        {
+            lua_pushnumber(L_, static_cast<lua_Number>(value));
+        }
+        else if constexpr (std::is_same_v<T, const char *>)
+        {
+            lua_pushstring(L_, value);
+        }
+        else if constexpr (std::is_same_v<T, std::string>)
+        {
+            lua_pushstring(L_, value.c_str());
+        }
+        else
+        {
+            static_assert(std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, const char *> ||
+                              std::is_same_v<T, std::string>,
+                          "Unsupported argument type for luaPushArgs");
+        }
     }
 
-    template <typename T>
-    T getReturnValue(int index)
+    template <typename T> T getReturnValue(int index)
     {
-      if (lua_isnil(L_, index))
-      {
-        return T();
-      }
-
-      if constexpr (std::is_same_v<T, std::string>)
-      {
-        size_t len;
-        const char *cstr = lua_tolstring(L_, index, &len);
-        return std::string(cstr, len);
-      }
-      else if constexpr (std::is_same_v<T, std::vector<std::string>>)
-      {
-        std::vector<std::string> result;
-
-        luaL_checktype(L_, index, LUA_TTABLE);
-        lua_pushnil(L_);
-        while (lua_next(L_, index - 1) != 0)
+        if (lua_isnil(L_, index))
         {
-          if (lua_isstring(L_, -1))
-          {
-            result.emplace_back(lua_tostring(L_, -1));
-          }
-          lua_pop(L_, 1);
+            return T();
         }
 
-        return result;
-      }
-      else if constexpr (std::is_same_v<T, std::vector<unsigned>>)
-      {
-        std::vector<unsigned> result;
-
-        luaL_checktype(L_, index, LUA_TTABLE);
-        lua_pushnil(L_);
-        while (lua_next(L_, index - 1) != 0)
+        if constexpr (std::is_same_v<T, std::string>)
         {
-          if (lua_isinteger(L_, -1))
-          {
-            result.emplace_back(lua_tointeger(L_, -1));
-          }
-          lua_pop(L_, 1);
+            size_t len;
+            const char *cstr = lua_tolstring(L_, index, &len);
+            return std::string(cstr, len);
+        }
+        else if constexpr (std::is_same_v<T, std::vector<std::string>>)
+        {
+            std::vector<std::string> result;
+
+            luaL_checktype(L_, index, LUA_TTABLE);
+            lua_pushnil(L_);
+            while (lua_next(L_, index - 1) != 0)
+            {
+                if (lua_isstring(L_, -1))
+                {
+                    result.emplace_back(lua_tostring(L_, -1));
+                }
+                lua_pop(L_, 1);
+            }
+
+            return result;
+        }
+        else if constexpr (std::is_same_v<T, std::vector<unsigned>>)
+        {
+            std::vector<unsigned> result;
+
+            luaL_checktype(L_, index, LUA_TTABLE);
+            lua_pushnil(L_);
+            while (lua_next(L_, index - 1) != 0)
+            {
+                if (lua_isinteger(L_, -1))
+                {
+                    result.emplace_back(lua_tointeger(L_, -1));
+                }
+                lua_pop(L_, 1);
+            }
+
+            return result;
+        }
+        else if constexpr (std::is_same_v<T, TableReference>)
+        {
+            lua_pushvalue(L_, index);
+            int ref = luaL_ref(L_, LUA_REGISTRYINDEX);
+            return static_cast<T>(ref);
+        }
+        else if constexpr (std::is_integral_v<T>)
+        {
+            return static_cast<T>(lua_tointeger(L_, index));
+        }
+        else if constexpr (std::is_floating_point_v<T>)
+        {
+            return static_cast<T>(lua_tonumber(L_, index));
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            return static_cast<T>(lua_toboolean(L_, index));
         }
 
-        return result;
-      }
-      else if constexpr (std::is_same_v<T, TableReference>)
-      {
-        lua_pushvalue(L_, index);
-        int ref = luaL_ref(L_, LUA_REGISTRYINDEX);
-        return static_cast<T>(ref);
-      }
-      else if constexpr (std::is_integral_v<T>)
-      {
-        return static_cast<T>(lua_tointeger(L_, index));
-      }
-      else if constexpr (std::is_floating_point_v<T>)
-      {
-        return static_cast<T>(lua_tonumber(L_, index));
-      }
-      else if constexpr (std::is_same_v<T, bool>)
-      {
-        return static_cast<T>(lua_toboolean(L_, index));
-      }
-
-      throw LuaException("Unsupported return type");
+        throw LuaException("Unsupported return type");
     }
 
     bool checkLuaTable(lua_State *L, int tableRef);
-  };
-}
+};
+} // namespace LuaScripting

--- a/model/cpp/luabind/lua_script_executor.cc
+++ b/model/cpp/luabind/lua_script_executor.cc
@@ -6,86 +6,86 @@
 
 namespace LuaScripting
 {
-  ScriptExecutor::ScriptExecutor(lua_State *ctx)
-  {
+ScriptExecutor::ScriptExecutor(lua_State *ctx)
+{
     luactx = ctx;
-  }
+}
 
-  bool ScriptExecutor::loadScriptFromString(const char *script)
-  {    
+bool ScriptExecutor::loadScriptFromString(const char *script)
+{
     int result = luaL_loadstring(luactx, script);
     if (result != LUA_OK)
     {
-      const char *errorMessage = lua_tostring(luactx, -1);
-      LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
-      return false;
+        const char *errorMessage = lua_tostring(luactx, -1);
+        LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
+        return false;
     }
     return true;
-  }
+}
 
-  bool ScriptExecutor::loadScriptFromTextFile(const char *fileName)
-  {   
+bool ScriptExecutor::loadScriptFromTextFile(const char *fileName)
+{
     int result = luaL_loadfile(luactx, fileName);
     if (result != LUA_OK)
     {
-      const char *errorMessage = lua_tostring(luactx, -1);
-      LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
-      return false;
+        const char *errorMessage = lua_tostring(luactx, -1);
+        LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
+        return false;
     }
     return true;
-  }
+}
 
-  bool ScriptExecutor::loadScriptFromBinaryFile(const char *fileName)
-  {    
+bool ScriptExecutor::loadScriptFromBinaryFile(const char *fileName)
+{
     return false;
-  }
+}
 
-  void ScriptExecutor::loadScriptFromResource(const unsigned char *start, const unsigned char *end)
-  {    
+void ScriptExecutor::loadScriptFromResource(const unsigned char *start, const unsigned char *end)
+{
     lua_State *L = luactx;
     int bytecodeSize = end - start;
 
     if (luaL_loadbuffer(L, reinterpret_cast<const char *>(start), bytecodeSize, "embedded_lua") == 0)
     {
-      int result = lua_pcall(L, 0, 0, 0);
-      if (result != 0)
-      {
-        const char *errorMsg = lua_tostring(L, -1);
-      }
+        int result = lua_pcall(L, 0, 0, 0);
+        if (result != 0)
+        {
+            const char *errorMsg = lua_tostring(L, -1);
+        }
     }
     else
     {
-      const char *errorMsg = lua_tostring(L, -1);
+        const char *errorMsg = lua_tostring(L, -1);
     }
 
     lua_close(L);
-  }
+}
 
-  bool ScriptExecutor::isFuncExists(const char *funcName)
-  {    
+bool ScriptExecutor::isFuncExists(const char *funcName)
+{
     lua_getglobal(luactx, funcName);
     if (lua_isfunction(luactx, lua_gettop(this->luactx)))
     {
-      return true;
+        return true;
     }
     return false;
-  }
+}
 
-  void ScriptExecutor::execute()
-  {
+void ScriptExecutor::execute()
+{
     int result = lua_pcall(luactx, 0, 0, 0);
     if (result != LUA_OK)
     {
-      const char *errorMessage = lua_tostring(luactx, -1);
-      LOG_DEBUG("Lua Error: {}\n", errorMessage);
+        const char *errorMessage = lua_tostring(luactx, -1);
+        LOG_DEBUG("Lua Error: {}\n", errorMessage);
     }
-  }
 }
+} // namespace LuaScripting
 
 bool runScriptFromTextFile(lua_State *ctx, const char *fileName)
 {
-  auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(ctx);
-  bool result = scripter->loadScriptFromTextFile(fileName);
-  scripter->execute();
-  return result;
+    auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(ctx);
+    bool result = scripter->loadScriptFromTextFile(fileName);
+    scripter->execute();
+    return result;
 }

--- a/model/cpp/luabind/lua_script_executor.hpp
+++ b/model/cpp/luabind/lua_script_executor.hpp
@@ -3,8 +3,8 @@
 
 namespace LuaScripting
 {
-  class ScriptExecutor
-  {
+class ScriptExecutor
+{
   public:
     ScriptExecutor(lua_State *ctx);
 
@@ -17,5 +17,5 @@ namespace LuaScripting
   private:
     bool isFuncExists(const char *funcName);
     lua_State *luactx;
-  };
-}
+};
+} // namespace LuaScripting

--- a/model/cpp/luabind/luabind.c
+++ b/model/cpp/luabind/luabind.c
@@ -17,64 +17,64 @@
 
 /// @brief	The lua variable API list[]=.
 static const lua_bind_var lua_var_api_list[] = ///< The lua variable API list[]=
-  {
-    /* Logic states */
-    {.var_name = "SHI", .var_value = SHI},
-    {.var_name = "SLO", .var_value = SLO},
-    {.var_name = "FLT", .var_value = FLT},
-    {.var_name = "PLO", .var_value = PLO},
-    {.var_name = "ILO", .var_value = ILO},
-    {.var_name = "WLO", .var_value = WLO},
-    {.var_name = "WHI", .var_value = WHI},
-    {.var_name = "IHI", .var_value = IHI},
-    {.var_name = "PHI", .var_value = PHI},
-    {.var_name = "WUD", .var_value = WUD},
-    {.var_name = "SUD", .var_value = SUD},
-    {.var_name = "TSTATE", .var_value = TSTATE},
-    {.var_name = "FSTATE", .var_value = FSTATE},
-    {.var_name = "UNDEFINED", .var_value = UNDEFINED},
-    /* Time suffixes */
-    {.var_name = "MSEC", .var_value = 1000000000L},
-    {.var_name = "NSEC", .var_value = 100000000L},
-    {.var_name = "USEC", .var_value = 1000000L},
-    {.var_name = "SEC", .var_value = 1000000000000L},
-    {.var_name = "NOW", .var_value = 0L},
-    /* Logic types */
-    {.var_name = "TTL", .var_value = TTL},
-    {.var_name = "CMOS", .var_value = CMOS},
-    {.var_name = "I2L", .var_value = I2L},
-    {.var_name = NULL},
+    {
+        /* Logic states */
+        {.var_name = "SHI", .var_value = SHI},
+        {.var_name = "SLO", .var_value = SLO},
+        {.var_name = "FLT", .var_value = FLT},
+        {.var_name = "PLO", .var_value = PLO},
+        {.var_name = "ILO", .var_value = ILO},
+        {.var_name = "WLO", .var_value = WLO},
+        {.var_name = "WHI", .var_value = WHI},
+        {.var_name = "IHI", .var_value = IHI},
+        {.var_name = "PHI", .var_value = PHI},
+        {.var_name = "WUD", .var_value = WUD},
+        {.var_name = "SUD", .var_value = SUD},
+        {.var_name = "TSTATE", .var_value = TSTATE},
+        {.var_name = "FSTATE", .var_value = FSTATE},
+        {.var_name = "UNDEFINED", .var_value = UNDEFINED},
+        /* Time suffixes */
+        {.var_name = "MSEC", .var_value = 1000000000L},
+        {.var_name = "NSEC", .var_value = 100000000L},
+        {.var_name = "USEC", .var_value = 1000000L},
+        {.var_name = "SEC", .var_value = 1000000000000L},
+        {.var_name = "NOW", .var_value = 0L},
+        /* Logic types */
+        {.var_name = "TTL", .var_value = TTL},
+        {.var_name = "CMOS", .var_value = CMOS},
+        {.var_name = "I2L", .var_value = I2L},
+        {.var_name = NULL},
 };
 
 /// @brief	The lua c API list[].
 static const lua_bind_func lua_c_api_list[] = ///< The lua c API list[]
-  {
-    {.lua_func_name = "state_to_string", .lua_c_api = &lua_state_to_string, .args = {LSTRING}},
-    {.lua_func_name = "info", .lua_c_api = &lua_print_info, .args = {LSTRING}},
-    {.lua_func_name = "message", .lua_c_api = &lua_print_message, .args = {LSTRING}},
-    {.lua_func_name = "warning", .lua_c_api = &lua_print_warning, .args = {LSTRING}},
-    {.lua_func_name = "error", .lua_c_api = &lua_print_error, .args = {LSTRING}},
-    {.lua_func_name = "set_callback", .lua_c_api = &lua_set_callback, .args = {LINT, LINT}},
-    {.lua_func_name = "create_debug_popup", .lua_c_api = &lua_create_debug_popup, .args = {LSTRING}},
-    {.lua_func_name = "create_memory_popup", .lua_c_api = &lua_create_memory_popup, .args = {LSTRING}},
-    {.lua_func_name = "create_source_popup", .lua_c_api = &lua_create_source_popup, .args = {LSTRING}},
-    {.lua_func_name = "create_status_popup", .lua_c_api = &lua_create_status_popup, .args = {LSTRING}},
-    {.lua_func_name = "create_var_popup", .lua_c_api = &lua_create_var_popup, .args = {LSTRING}},
-    {.lua_func_name = "delete_popup", .lua_c_api = &lua_delete_popup, .args = {LINT}},
-    {.lua_func_name = "set_memory_popup", .lua_c_api = &lua_set_memory_popup},
-    {.lua_func_name = "repaint_memory_popup", .lua_c_api = &lua_repaint_memory_popup},
-    {.lua_func_name = "print_to_debug_popup", .lua_c_api = &lua_print_to_debug_popup},
-    {.lua_func_name = "dump_to_debug_popup", .lua_c_api = &lua_dump_to_debug_popup},
-    {.lua_func_name = "get_string_param", .lua_c_api = &lua_get_string_param},
-    {.lua_func_name = "get_num_param", .lua_c_api = &lua_get_num_param},
-    {.lua_func_name = "get_bool_param", .lua_c_api = &lua_get_bool_param},
-    {.lua_func_name = "get_init_param", .lua_c_api = &lua_get_init_param},
-    {.lua_func_name = "get_hex_param", .lua_c_api = &lua_get_hex_param},
-    {.lua_func_name = "add_source_file", .lua_c_api = &lua_add_source_file},
-    {.lua_func_name = "systime", .lua_c_api = &lua_get_systime},
-    {.lua_func_name = "set_bus", .lua_c_api = &lua_set_bus},
-    {.lua_func_name = "get_bus", .lua_c_api = &lua_get_bus},
-    {NULL, NULL},
+    {
+        {.lua_func_name = "state_to_string", .lua_c_api = &lua_state_to_string, .args = {LSTRING}},
+        {.lua_func_name = "info", .lua_c_api = &lua_print_info, .args = {LSTRING}},
+        {.lua_func_name = "message", .lua_c_api = &lua_print_message, .args = {LSTRING}},
+        {.lua_func_name = "warning", .lua_c_api = &lua_print_warning, .args = {LSTRING}},
+        {.lua_func_name = "error", .lua_c_api = &lua_print_error, .args = {LSTRING}},
+        {.lua_func_name = "set_callback", .lua_c_api = &lua_set_callback, .args = {LINT, LINT}},
+        {.lua_func_name = "create_debug_popup", .lua_c_api = &lua_create_debug_popup, .args = {LSTRING}},
+        {.lua_func_name = "create_memory_popup", .lua_c_api = &lua_create_memory_popup, .args = {LSTRING}},
+        {.lua_func_name = "create_source_popup", .lua_c_api = &lua_create_source_popup, .args = {LSTRING}},
+        {.lua_func_name = "create_status_popup", .lua_c_api = &lua_create_status_popup, .args = {LSTRING}},
+        {.lua_func_name = "create_var_popup", .lua_c_api = &lua_create_var_popup, .args = {LSTRING}},
+        {.lua_func_name = "delete_popup", .lua_c_api = &lua_delete_popup, .args = {LINT}},
+        {.lua_func_name = "set_memory_popup", .lua_c_api = &lua_set_memory_popup},
+        {.lua_func_name = "repaint_memory_popup", .lua_c_api = &lua_repaint_memory_popup},
+        {.lua_func_name = "print_to_debug_popup", .lua_c_api = &lua_print_to_debug_popup},
+        {.lua_func_name = "dump_to_debug_popup", .lua_c_api = &lua_dump_to_debug_popup},
+        {.lua_func_name = "get_string_param", .lua_c_api = &lua_get_string_param},
+        {.lua_func_name = "get_num_param", .lua_c_api = &lua_get_num_param},
+        {.lua_func_name = "get_bool_param", .lua_c_api = &lua_get_bool_param},
+        {.lua_func_name = "get_init_param", .lua_c_api = &lua_get_init_param},
+        {.lua_func_name = "get_hex_param", .lua_c_api = &lua_get_hex_param},
+        {.lua_func_name = "add_source_file", .lua_c_api = &lua_add_source_file},
+        {.lua_func_name = "systime", .lua_c_api = &lua_get_systime},
+        {.lua_func_name = "set_bus", .lua_c_api = &lua_set_bus},
+        {.lua_func_name = "get_bus", .lua_c_api = &lua_get_bus},
+        {NULL, NULL},
 };
 
 /**
@@ -92,54 +92,54 @@ static const lua_bind_func lua_c_api_list[] = ///< The lua c API list[]
 
 void lua_load_modules(IDSIMMODEL *this)
 {
-  if (luaL_loadbuffer(this->luactx, module_custom_mod, module_custom_mod_len, "custom_assignments"))
-  {
-    PRINT(this, "Failed to load CUSTOM module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
-  if (luaL_loadbuffer(this->luactx, module_bus_mod, module_bus_mod_len, "bus_class"))
-  {
-    PRINT(this, "Failed to load BUS module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
-  if (luaL_loadbuffer(this->luactx, module_events_mod, module_events_mod_len, "events_class"))
-  {
-    PRINT(this, "Failed to load EVENTS module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
-  if (luaL_loadbuffer(this->luactx, device_mod, device_mod_len, "precompiled_device"))
-  {
-    PRINT(this, "Failed to load DEVICE module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
-  if (luaL_loadbuffer(this->luactx, module_fifo_mod, module_fifo_mod_len, "fifo_class"))
-  {
-    PRINT(this, "Failed to load FIFO module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
-  if (luaL_loadbuffer(this->luactx, module_uart_mod, module_uart_mod_len, "uart_class"))
-  {
-    PRINT(this, "Failed to load UART module");
-  }
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to precompile module");
-  }
+    if (luaL_loadbuffer(this->luactx, module_custom_mod, module_custom_mod_len, "custom_assignments"))
+    {
+        PRINT(this, "Failed to load CUSTOM module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
+    if (luaL_loadbuffer(this->luactx, module_bus_mod, module_bus_mod_len, "bus_class"))
+    {
+        PRINT(this, "Failed to load BUS module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
+    if (luaL_loadbuffer(this->luactx, module_events_mod, module_events_mod_len, "events_class"))
+    {
+        PRINT(this, "Failed to load EVENTS module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
+    if (luaL_loadbuffer(this->luactx, device_mod, device_mod_len, "precompiled_device"))
+    {
+        PRINT(this, "Failed to load DEVICE module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
+    if (luaL_loadbuffer(this->luactx, module_fifo_mod, module_fifo_mod_len, "fifo_class"))
+    {
+        PRINT(this, "Failed to load FIFO module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
+    if (luaL_loadbuffer(this->luactx, module_uart_mod, module_uart_mod_len, "uart_class"))
+    {
+        PRINT(this, "Failed to load UART module");
+    }
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to precompile module");
+    }
 }
 
 /**
@@ -156,59 +156,63 @@ void lua_load_modules(IDSIMMODEL *this)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static void
-safe_execute(lua_State *L, void *curfunc)
+static void safe_execute(lua_State *L, void *curfunc)
 {
-  /* Call trace */
-  /*calltrace* new = NULL;
-  HASH_FIND_INT ( this->trace, &curfunc, new );
-  if ( !new )
-  {
-      new = malloc ( sizeof *new );
-      new->func_addr = curfunc;
-      HASH_ADD_INT ( this->trace, func_addr, new );
-  }*/
-  /*=============*/
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  if (!this->safe_mode)
-    return;
-
-  int argnum = lua_gettop(L);
-  for (int i = 0; lua_c_api_list[i].lua_func_name; i++)
-  {
-    if (curfunc == lua_c_api_list[i].lua_c_api)
+    /* Call trace */
+    /*calltrace* new = NULL;
+    HASH_FIND_INT ( this->trace, &curfunc, new );
+    if ( !new )
     {
-      int argcount = 0;
-      for (argcount = 0; lua_c_api_list[i].args[argcount]; argcount++)
-      {
-        if (argnum < argcount + 1)
-        {
-          lua_Debug ar;
-          lua_getstack(L, 1, &ar);
-          lua_getinfo(L, "nSl", &ar);
-          int line = ar.currentline;
-
-          print_error(this, "Line %d: Too few arguments passed to the function \"%s\"", line, lua_c_api_list[i].lua_func_name);
-        }
-        else if (!lua_c_api_list[i].args[argcount](L, argcount + 1))
-        {
-          lua_Debug ar;
-          lua_getstack(L, 1, &ar);
-          lua_getinfo(L, "nSl", &ar);
-          int line = ar.currentline;
-          print_error(this, "Line %d: Argument %d of \"%s\" is of wrong type [%s]", line, argcount + 1, lua_c_api_list[i].lua_func_name, lua_typename(L, argcount + 1));
-        }
-      }
-      if (lua_c_api_list[i].args[argcount + 2])
-      {
-        lua_Debug ar;
-        lua_getstack(L, 1, &ar);
-        lua_getinfo(L, "nSl", &ar);
-        int line = ar.currentline;
-        print_error(this, "Line %d: extra arguments passed to \"%s\"", line, argcount + 1, lua_c_api_list[i].lua_func_name);
-      }
+        new = malloc ( sizeof *new );
+        new->func_addr = curfunc;
+        HASH_ADD_INT ( this->trace, func_addr, new );
+    }*/
+    /*=============*/
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    if (!this->safe_mode)
+    {
+        return;
     }
-  }
+
+    int argnum = lua_gettop(L);
+    for (int i = 0; lua_c_api_list[i].lua_func_name; i++)
+    {
+        if (curfunc == lua_c_api_list[i].lua_c_api)
+        {
+            int argcount = 0;
+            for (argcount = 0; lua_c_api_list[i].args[argcount]; argcount++)
+            {
+                if (argnum < argcount + 1)
+                {
+                    lua_Debug ar;
+                    lua_getstack(L, 1, &ar);
+                    lua_getinfo(L, "nSl", &ar);
+                    int line = ar.currentline;
+
+                    print_error(this, "Line %d: Too few arguments passed to the function \"%s\"", line,
+                                lua_c_api_list[i].lua_func_name);
+                }
+                else if (!lua_c_api_list[i].args[argcount](L, argcount + 1))
+                {
+                    lua_Debug ar;
+                    lua_getstack(L, 1, &ar);
+                    lua_getinfo(L, "nSl", &ar);
+                    int line = ar.currentline;
+                    print_error(this, "Line %d: Argument %d of \"%s\" is of wrong type [%s]", line, argcount + 1,
+                                lua_c_api_list[i].lua_func_name, lua_typename(L, argcount + 1));
+                }
+            }
+            if (lua_c_api_list[i].args[argcount + 2])
+            {
+                lua_Debug ar;
+                lua_getstack(L, 1, &ar);
+                lua_getinfo(L, "nSl", &ar);
+                int line = ar.currentline;
+                print_error(this, "Line %d: extra arguments passed to \"%s\"", line, argcount + 1,
+                            lua_c_api_list[i].lua_func_name);
+            }
+        }
+    }
 }
 
 /**
@@ -227,18 +231,18 @@ safe_execute(lua_State *L, void *curfunc)
 
 void register_functions(IDSIMMODEL *this, lua_State *L)
 {
-  /*  Declare functions */
-  for (int i = 0; lua_c_api_list[i].lua_func_name; i++)
-  {
-    lua_pushcfunction(L, lua_c_api_list[i].lua_c_api);
-    lua_setglobal(L, lua_c_api_list[i].lua_func_name);
-  }
-  /* Declare variables */
-  for (int i = 0; lua_var_api_list[i].var_name; i++)
-  {
-    lua_pushinteger(L, lua_var_api_list[i].var_value);
-    lua_setglobal(L, lua_var_api_list[i].var_name);
-  }
+    /*  Declare functions */
+    for (int i = 0; lua_c_api_list[i].lua_func_name; i++)
+    {
+        lua_pushcfunction(L, lua_c_api_list[i].lua_c_api);
+        lua_setglobal(L, lua_c_api_list[i].lua_func_name);
+    }
+    /* Declare variables */
+    for (int i = 0; lua_var_api_list[i].var_name; i++)
+    {
+        lua_pushinteger(L, lua_var_api_list[i].var_value);
+        lua_setglobal(L, lua_var_api_list[i].var_name);
+    }
 }
 
 /**
@@ -259,46 +263,46 @@ void register_functions(IDSIMMODEL *this, lua_State *L)
 
 bool load_device_script(IDSIMMODEL *this, const char *device_name)
 {
-  char spath[512] = {0};
-  if (0 == GetEnvironmentVariable("LUAVSM", spath, sizeof spath))
-  {
-    print_error(this, "LUAVSM environment variable is not set");
-    return false;
-  }
-  char *script = NULL;
-  asprintf(&script, "%s%s%s", spath, '\\' == spath[strlen(spath) - 1] ? "" : "\\", device_name);
-
-  int lua_err = luaL_loadfile(this->luactx, script);
-
-  if (0 != lua_err)
-  {
-    const char *mess = NULL;
-    switch (lua_err)
+    char spath[512] = {0};
+    if (0 == GetEnvironmentVariable("LUAVSM", spath, sizeof spath))
     {
-    case LUA_ERRSYNTAX:
-      mess = lua_tostring(this->luactx, FIRST_ARG);
-      print_error(this, "Syntax error in Lua script\n%s", mess);
-      return false;
-    case LUA_ERRMEM:
-      print_error(this, "Not enough memory to load script \"%s\"", script);
-      return false;
-    case LUA_ERRFILE:
-      print_error(this, "Error opening/loading script file \"%s\"", script);
-      return false;
-    default:
-      print_error(this, "Unknown error, shouldn't happen");
-      assert(0);
+        print_error(this, "LUAVSM environment variable is not set");
+        return false;
     }
-  }
-  /* Primer run, if not run it - nothing works, need for parse */
-  if (0 != lua_pcall(this->luactx, 0, 0, 0))
-  {
-    print_error(this, "Failed to load the script \"%s\"", script);
+    char *script = NULL;
+    asprintf(&script, "%s%s%s", spath, '\\' == spath[strlen(spath) - 1] ? "" : "\\", device_name);
+
+    int lua_err = luaL_loadfile(this->luactx, script);
+
+    if (0 != lua_err)
+    {
+        const char *mess = NULL;
+        switch (lua_err)
+        {
+        case LUA_ERRSYNTAX:
+            mess = lua_tostring(this->luactx, FIRST_ARG);
+            print_error(this, "Syntax error in Lua script\n%s", mess);
+            return false;
+        case LUA_ERRMEM:
+            print_error(this, "Not enough memory to load script \"%s\"", script);
+            return false;
+        case LUA_ERRFILE:
+            print_error(this, "Error opening/loading script file \"%s\"", script);
+            return false;
+        default:
+            print_error(this, "Unknown error, shouldn't happen");
+            assert(0);
+        }
+    }
+    /* Primer run, if not run it - nothing works, need for parse */
+    if (0 != lua_pcall(this->luactx, 0, 0, 0))
+    {
+        print_error(this, "Failed to load the script \"%s\"", script);
+        free(script);
+        return false;
+    }
     free(script);
-    return false;
-  }
-  free(script);
-  return true;
+    return true;
 }
 
 /**
@@ -316,14 +320,13 @@ bool load_device_script(IDSIMMODEL *this, const char *device_name)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_string_param(lua_State *L)
+static int lua_get_string_param(lua_State *L)
 {
-  safe_execute(L, &lua_get_string_param);
-  char *str = (char *)lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushstring(L, get_string_param(this, str));
-  return 1;
+    safe_execute(L, &lua_get_string_param);
+    char *str = (char *)lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushstring(L, get_string_param(this, str));
+    return 1;
 }
 
 /**
@@ -341,14 +344,13 @@ lua_get_string_param(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_bool_param(lua_State *L)
+static int lua_get_bool_param(lua_State *L)
 {
-  safe_execute(L, &lua_get_bool_param);
-  char *str = (char *)lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushinteger(L, get_bool_param(this, str));
-  return 1;
+    safe_execute(L, &lua_get_bool_param);
+    char *str = (char *)lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushinteger(L, get_bool_param(this, str));
+    return 1;
 }
 
 /**
@@ -366,14 +368,13 @@ lua_get_bool_param(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_num_param(lua_State *L)
+static int lua_get_num_param(lua_State *L)
 {
-  safe_execute(L, &lua_get_num_param);
-  char *str = (char *)lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushinteger(L, get_num_param(this, str));
-  return 1;
+    safe_execute(L, &lua_get_num_param);
+    char *str = (char *)lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushinteger(L, get_num_param(this, str));
+    return 1;
 }
 
 /**
@@ -391,14 +392,13 @@ lua_get_num_param(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_hex_param(lua_State *L)
+static int lua_get_hex_param(lua_State *L)
 {
-  safe_execute(L, &lua_get_hex_param);
-  char *str = (char *)lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushinteger(L, get_hex_param(this, str));
-  return 1;
+    safe_execute(L, &lua_get_hex_param);
+    char *str = (char *)lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushinteger(L, get_hex_param(this, str));
+    return 1;
 }
 
 /**
@@ -416,14 +416,13 @@ lua_get_hex_param(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_init_param(lua_State *L)
+static int lua_get_init_param(lua_State *L)
 {
-  safe_execute(L, &lua_get_init_param);
-  char *str = (char *)lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushinteger(L, get_init_param(this, str));
-  return 1;
+    safe_execute(L, &lua_get_init_param);
+    char *str = (char *)lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushinteger(L, get_init_param(this, str));
+    return 1;
 }
 
 /**
@@ -441,14 +440,13 @@ lua_get_init_param(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_delete_popup(lua_State *L)
+static int lua_delete_popup(lua_State *L)
 {
-  safe_execute(L, &lua_delete_popup);
-  ptrdiff_t id = lua_tointeger(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  delete_popup(this, id);
-  return 0;
+    safe_execute(L, &lua_delete_popup);
+    ptrdiff_t id = lua_tointeger(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    delete_popup(this, id);
+    return 0;
 }
 
 /**
@@ -466,15 +464,14 @@ lua_delete_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_create_debug_popup(lua_State *L)
+static int lua_create_debug_popup(lua_State *L)
 {
-  safe_execute(L, &lua_create_debug_popup);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushlightuserdata(L, create_debug_popup(this, text, ++this->popup_id));
-  lua_pushinteger(L, this->popup_id);
-  return 2;
+    safe_execute(L, &lua_create_debug_popup);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushlightuserdata(L, create_debug_popup(this, text, ++this->popup_id));
+    lua_pushinteger(L, this->popup_id);
+    return 2;
 }
 
 /**
@@ -492,14 +489,13 @@ lua_create_debug_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_print_to_debug_popup(lua_State *L)
+static int lua_print_to_debug_popup(lua_State *L)
 {
-  safe_execute(L, &lua_print_to_debug_popup);
-  const char *str = lua_tostring(L, FIRST_ARG);
-  void *popup = lua_touserdata(L, SECOND_ARG);
-  print_to_debug_popup(popup, str);
-  return 0;
+    safe_execute(L, &lua_print_to_debug_popup);
+    const char *str = lua_tostring(L, FIRST_ARG);
+    void *popup = lua_touserdata(L, SECOND_ARG);
+    print_to_debug_popup(popup, str);
+    return 0;
 }
 
 /**
@@ -517,16 +513,15 @@ lua_print_to_debug_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_dump_to_debug_popup(lua_State *L)
+static int lua_dump_to_debug_popup(lua_State *L)
 {
-  safe_execute(L, &lua_dump_to_debug_popup);
-  lua_Number offset = luaL_checknumber(L, FIRST_ARG);
-  lua_Number size = luaL_checknumber(L, SECOND_ARG);
-  const char *buf = luaL_checkstring(L, THIRD_ARG);
-  void *popup = lua_touserdata(L, FORTH_ARG);
-  dump_to_debug_popup(popup, (BYTE *)buf, offset, size);
-  return 0;
+    safe_execute(L, &lua_dump_to_debug_popup);
+    lua_Number offset = luaL_checknumber(L, FIRST_ARG);
+    lua_Number size = luaL_checknumber(L, SECOND_ARG);
+    const char *buf = luaL_checkstring(L, THIRD_ARG);
+    void *popup = lua_touserdata(L, FORTH_ARG);
+    dump_to_debug_popup(popup, (BYTE *)buf, offset, size);
+    return 0;
 }
 
 /**
@@ -544,15 +539,14 @@ lua_dump_to_debug_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_create_source_popup(lua_State *L)
+static int lua_create_source_popup(lua_State *L)
 {
-  safe_execute(L, &lua_create_source_popup);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushlightuserdata(L, create_source_popup(this, text, ++this->popup_id));
-  lua_pushinteger(L, this->popup_id);
-  return 2;
+    safe_execute(L, &lua_create_source_popup);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushlightuserdata(L, create_source_popup(this, text, ++this->popup_id));
+    lua_pushinteger(L, this->popup_id);
+    return 2;
 }
 
 /**
@@ -570,15 +564,14 @@ lua_create_source_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_create_status_popup(lua_State *L)
+static int lua_create_status_popup(lua_State *L)
 {
-  safe_execute(L, &lua_create_status_popup);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushlightuserdata(L, create_status_popup(this, text, ++this->popup_id));
-  lua_pushinteger(L, this->popup_id);
-  return 2;
+    safe_execute(L, &lua_create_status_popup);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushlightuserdata(L, create_status_popup(this, text, ++this->popup_id));
+    lua_pushinteger(L, this->popup_id);
+    return 2;
 }
 
 /**
@@ -596,15 +589,14 @@ lua_create_status_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_create_var_popup(lua_State *L)
+static int lua_create_var_popup(lua_State *L)
 {
-  safe_execute(L, &lua_create_var_popup);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushlightuserdata(L, create_var_popup(this, text, ++this->popup_id));
-  lua_pushinteger(L, this->popup_id);
-  return 2;
+    safe_execute(L, &lua_create_var_popup);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushlightuserdata(L, create_var_popup(this, text, ++this->popup_id));
+    lua_pushinteger(L, this->popup_id);
+    return 2;
 }
 
 /**
@@ -622,15 +614,14 @@ lua_create_var_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_create_memory_popup(lua_State *L)
+static int lua_create_memory_popup(lua_State *L)
 {
-  safe_execute(L, &lua_create_memory_popup);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  lua_pushlightuserdata(L, create_memory_popup(this, text, ++this->popup_id));
-  lua_pushinteger(L, this->popup_id);
-  return 2;
+    safe_execute(L, &lua_create_memory_popup);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    lua_pushlightuserdata(L, create_memory_popup(this, text, ++this->popup_id));
+    lua_pushinteger(L, this->popup_id);
+    return 2;
 }
 
 /**
@@ -648,16 +639,15 @@ lua_create_memory_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_set_memory_popup(lua_State *L)
+static int lua_set_memory_popup(lua_State *L)
 {
-  safe_execute(L, &lua_set_memory_popup);
-  lua_Number size = luaL_checknumber(L, FIRST_ARG);
-  const char *buf = luaL_checkstring(L, SECOND_ARG);
-  void *popup = lua_touserdata(L, THIRD_ARG);
-  set_memory_popup(popup, 0, (void *)buf, size);
+    safe_execute(L, &lua_set_memory_popup);
+    lua_Number size = luaL_checknumber(L, FIRST_ARG);
+    const char *buf = luaL_checkstring(L, SECOND_ARG);
+    void *popup = lua_touserdata(L, THIRD_ARG);
+    set_memory_popup(popup, 0, (void *)buf, size);
 
-  return 0;
+    return 0;
 }
 
 /**
@@ -675,17 +665,17 @@ lua_set_memory_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_add_source_file(lua_State *L)
+static int lua_add_source_file(lua_State *L)
 {
-  safe_execute(L, &lua_add_source_file);
-  if (false == add_source_file(lua_touserdata(L, THIRD_ARG), (char *)lua_tostring(L, SECOND_ARG), lua_tointeger(L, FIRST_ARG)))
-  {
-    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-    print_info(this, "Fail to load source file");
-  }
+    safe_execute(L, &lua_add_source_file);
+    if (false ==
+        add_source_file(lua_touserdata(L, THIRD_ARG), (char *)lua_tostring(L, SECOND_ARG), lua_tointeger(L, FIRST_ARG)))
+    {
+        IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+        print_info(this, "Fail to load source file");
+    }
 
-  return 0;
+    return 0;
 }
 
 /**
@@ -703,13 +693,12 @@ lua_add_source_file(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_repaint_memory_popup(lua_State *L)
+static int lua_repaint_memory_popup(lua_State *L)
 {
-  safe_execute(L, &lua_repaint_memory_popup);
-  void *popup = lua_touserdata(L, FIRST_ARG);
-  repaint_memory_popup(popup);
-  return 0;
+    safe_execute(L, &lua_repaint_memory_popup);
+    void *popup = lua_touserdata(L, FIRST_ARG);
+    repaint_memory_popup(popup);
+    return 0;
 }
 
 /**
@@ -727,15 +716,14 @@ lua_repaint_memory_popup(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_state_to_string(lua_State *L)
+static int lua_state_to_string(lua_State *L)
 {
-  safe_execute(L, &lua_state_to_string);
-  ptrdiff_t state = lua_tointeger(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    safe_execute(L, &lua_state_to_string);
+    ptrdiff_t state = lua_tointeger(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
 
-  lua_pushstring(L, state_to_string(state));
-  return 1;
+    lua_pushstring(L, state_to_string(state));
+    return 1;
 }
 
 /**
@@ -753,14 +741,13 @@ lua_state_to_string(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_print_info(lua_State *L)
+static int lua_print_info(lua_State *L)
 {
-  safe_execute(L, &lua_print_info);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  print_info(this, text);
-  return 0;
+    safe_execute(L, &lua_print_info);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    print_info(this, text);
+    return 0;
 }
 
 /**
@@ -778,14 +765,13 @@ lua_print_info(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_print_message(lua_State *L)
+static int lua_print_message(lua_State *L)
 {
-  safe_execute(L, &lua_print_message);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  print_message(this, text);
-  return 0;
+    safe_execute(L, &lua_print_message);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    print_message(this, text);
+    return 0;
 }
 
 /**
@@ -803,14 +789,13 @@ lua_print_message(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_print_warning(lua_State *L)
+static int lua_print_warning(lua_State *L)
 {
-  safe_execute(L, &lua_print_warning);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  print_warning(this, text);
-  return 0;
+    safe_execute(L, &lua_print_warning);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    print_warning(this, text);
+    return 0;
 }
 
 /**
@@ -828,14 +813,13 @@ lua_print_warning(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_print_error(lua_State *L)
+static int lua_print_error(lua_State *L)
 {
-  safe_execute(L, &lua_print_error);
-  const char *text = lua_tostring(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  print_error(this, text);
-  return 0;
+    safe_execute(L, &lua_print_error);
+    const char *text = lua_tostring(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    print_error(this, text);
+    return 0;
 }
 
 /**
@@ -853,15 +837,14 @@ lua_print_error(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_set_callback(lua_State *L)
+static int lua_set_callback(lua_State *L)
 {
-  safe_execute(L, &lua_set_callback);
-  lua_Number picotime = lua_tointeger(L, SECOND_ARG);
-  lua_Number eventid = lua_tointeger(L, FIRST_ARG);
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  set_callback(this, picotime, eventid);
-  return 0;
+    safe_execute(L, &lua_set_callback);
+    lua_Number picotime = lua_tointeger(L, SECOND_ARG);
+    lua_Number eventid = lua_tointeger(L, FIRST_ARG);
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    set_callback(this, picotime, eventid);
+    return 0;
 }
 
 /**
@@ -879,12 +862,11 @@ lua_set_callback(lua_State *L)
  * ### remarks	Pugnator, 11/21/2015.
  **/
 
-static int
-lua_get_systime(lua_State *L)
+static int lua_get_systime(lua_State *L)
 {
-  ABSTIME curtime = 0;
-  IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
-  systime(this, &curtime);
-  lua_pushinteger(L, curtime);
-  return 1;
+    ABSTIME curtime = 0;
+    IDSIMMODEL *this = (IDSIMMODEL *)lua_get_model_obj(L);
+    systime(this, &curtime);
+    lua_pushinteger(L, curtime);
+    return 1;
 }

--- a/model/cpp/luabind/module_config.hpp
+++ b/model/cpp/luabind/module_config.hpp
@@ -5,8 +5,8 @@
 
 struct Resource
 {
-  const char *data;
-  size_t size;
+    const char *data;
+    size_t size;
 };
 
 extern const std::vector<std::string> modulesToPreload;

--- a/model/cpp/luabind/resources_map.cc
+++ b/model/cpp/luabind/resources_map.cc
@@ -28,32 +28,30 @@ INCBIN(Lexicon, "wakadll/lua/lexicon/main.luac");
 INCBIN(LexiconPOS, "wakadll/lua/lexicon/word_pos.luac");
 INCBIN(LexiconNumerals, "wakadll/lua/lexicon/numerals.luac");
 
-const std::vector<std::string> modulesToPreload =
-    {
-        "LuaUnit",
-        "DictManager",
-        "UtfChars",
-        "SearchRequest",
-        "Inflector",
-        "IchidanInflector",
-        "GodanInflector",
-        "IrregularInflector",
-        "IAdjectiveInflector",
-        "NaAdjectiveInflector",
-        "Vowels",
-        "JlptTraining",
-        "TrainingExamples",
-        "TrainingTranslation",
-        "TrainingReading",
-        "TrainingKana",
-        "TrainingNumeral",
-        "TableHelpers",
-        "Lexicon",
-        "LexiconPOS",
-        "LexiconNumerals",
+const std::vector<std::string> modulesToPreload = {
+    "LuaUnit",
+    "DictManager",
+    "UtfChars",
+    "SearchRequest",
+    "Inflector",
+    "IchidanInflector",
+    "GodanInflector",
+    "IrregularInflector",
+    "IAdjectiveInflector",
+    "NaAdjectiveInflector",
+    "Vowels",
+    "JlptTraining",
+    "TrainingExamples",
+    "TrainingTranslation",
+    "TrainingReading",
+    "TrainingKana",
+    "TrainingNumeral",
+    "TableHelpers",
+    "Lexicon",
+    "LexiconPOS",
+    "LexiconNumerals",
 };
 
-const std::map<std::string, Resource> resourceMap =
-{
-        //{"LuaUnit", {reinterpret_cast<const char *>(lua_LuaUnitData), lua_LuaUnitSize}},
+const std::map<std::string, Resource> resourceMap = {
+    //{"LuaUnit", {reinterpret_cast<const char *>(lua_LuaUnitData), lua_LuaUnitSize}},
 };

--- a/model/cpp/luabind/waka_module.cc
+++ b/model/cpp/luabind/waka_module.cc
@@ -8,85 +8,85 @@
 
 static int lua_print(lua_State *L)
 {
-  int nargs = lua_gettop(L);
-  for (int i = 1; i <= nargs; i++)
-  {
-    if (lua_isstring(L, i))
+    int nargs = lua_gettop(L);
+    for (int i = 1; i <= nargs; i++)
     {
-      auto str = lua_tostring(L, i);
-      if (str)
-      {
-        LOG_INFO("{}", str);
-      }
-    }
+        if (lua_isstring(L, i))
+        {
+            auto str = lua_tostring(L, i);
+            if (str)
+            {
+                LOG_INFO("{}", str);
+            }
+        }
 
-    if (i < nargs)
-    {
-      LOG_INFO("\t");
+        if (i < nargs)
+        {
+            LOG_INFO("\t");
+        }
     }
-  }
-  LOG_INFO("\n");
-  return 0;
+    LOG_INFO("\n");
+    return 0;
 }
 
 static void requireAllModules(lua_State *L)
 {
-  for (const auto &moduleName : modulesToPreload)
-  {
-    lua_getglobal(L, "require");
-    lua_pushstring(L, moduleName.c_str());
-    if (lua_pcall(L, 1, 1, 0) != 0)
+    for (const auto &moduleName : modulesToPreload)
     {
-      LOG_DEBUG("Error requiring 'waka': {}\n", lua_tostring(L, -1));
-      lua_pop(L, 1);
-      throw LuaScripting::LuaException("Error requiring the module");
+        lua_getglobal(L, "require");
+        lua_pushstring(L, moduleName.c_str());
+        if (lua_pcall(L, 1, 1, 0) != 0)
+        {
+            LOG_DEBUG("Error requiring 'waka': {}\n", lua_tostring(L, -1));
+            lua_pop(L, 1);
+            throw LuaScripting::LuaException("Error requiring the module");
+        }
+        LOG_DEBUG("Module {} required successfully\n", moduleName);
     }
-    LOG_DEBUG("Module {} required successfully\n", moduleName);
-  }
 }
 
 extern "C" WAKA_API int luaopen_waka(lua_State *L)
 {
-  LOG_DEBUG("Loading Waka module\n");
-  luaL_openlibs(L);
-  // Logging from Lua function
-  lua_pushcfunction(L, lua_print);
-  lua_setglobal(L, "print");
+    LOG_DEBUG("Loading Waka module\n");
+    luaL_openlibs(L);
+    // Logging from Lua function
+    lua_pushcfunction(L, lua_print);
+    lua_setglobal(L, "print");
 
-  LuaScripting::registerDictManagement(L);
-  LuaScripting::registerKanaProcessor(L);
-  LuaScripting::registerDictSearch(L);
-  LuaScripting::registerUserNotes(L);
+    LuaScripting::registerDictManagement(L);
+    LuaScripting::registerKanaProcessor(L);
+    LuaScripting::registerDictSearch(L);
+    LuaScripting::registerUserNotes(L);
 
-  for (const auto &moduleName : modulesToPreload)
-  {
-    if (!LuaScripting::preloadModule(L, moduleName))
+    for (const auto &moduleName : modulesToPreload)
     {
-      LOG_DEBUG("Could not preload module {}\n", moduleName);
-      return 0;
+        if (!LuaScripting::preloadModule(L, moduleName))
+        {
+            LOG_DEBUG("Could not preload module {}\n", moduleName);
+            return 0;
+        }
     }
-  }
 
-  // Seed the random generator
+    // Seed the random generator
 
-  lua_getglobal(L, "os");
-  lua_getfield(L, -1, "time");
-  if (lua_pcall(L, 0, 1, 0) != LUA_OK)
-  {
-    LOG_DEBUG("Error calling os.time: {}\n", lua_tostring(L, -1));
-    return 0;
-  }
+    lua_getglobal(L, "os");
+    lua_getfield(L, -1, "time");
+    if (lua_pcall(L, 0, 1, 0) != LUA_OK)
+    {
+        LOG_DEBUG("Error calling os.time: {}\n", lua_tostring(L, -1));
+        return 0;
+    }
 
-  lua_getglobal(L, "math");
-  lua_getfield(L, -1, "randomseed");
-  lua_pushvalue(L, -3);
+    lua_getglobal(L, "math");
+    lua_getfield(L, -1, "randomseed");
+    lua_pushvalue(L, -3);
 
-  if (lua_pcall(L, 1, 0, 0) != LUA_OK)
-  {
-    LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(L, -1));
-    return 0;
-  }
+    if (lua_pcall(L, 1, 0, 0) != LUA_OK)
+    {
+        LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(L, -1));
+        return 0;
+    }
 
-  LOG_DEBUG("Waka module loaded\n");
-  return 1;
+    LOG_DEBUG("Waka module loaded\n");
+    return 1;
 }

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -7,28 +7,28 @@
 
 namespace
 {
-  int lua_print(lua_State *L)
-  {
+int lua_print(lua_State *L)
+{
     int nargs = lua_gettop(L);
     for (int i = 1; i <= nargs; i++)
     {
-      if (lua_isstring(L, i))
-      {
-        auto str = lua_tostring(L, i);
-        if (str)
+        if (lua_isstring(L, i))
         {
-          LOG_INFO("{}", str);
+            auto str = lua_tostring(L, i);
+            if (str)
+            {
+                LOG_INFO("{}", str);
+            }
         }
-      }
 
-      if (i < nargs)
-      {
-        LOG_INFO("\t");
-      }
+        if (i < nargs)
+        {
+            LOG_INFO("\t");
+        }
     }
     return 0;
-  }
 }
+} // namespace
 
 namespace DeviceSimulator
 {
@@ -37,12 +37,14 @@ namespace DeviceSimulator
 #define PIN_OFF_TIME "off_time"
 #define PIN_ON_TIME "on_time"
 
-  VirtualDevice::VirtualDevice()
-  {
+VirtualDevice::VirtualDevice()
+{
     LOG_DEBUG("Creating the device\n");
     luactx_ = luaL_newstate();
     if (!luactx_)
-      throw std::runtime_error("Failed to create a new Lua state");
+    {
+        throw std::runtime_error("Failed to create a new Lua state");
+    }
 
     luaL_openlibs(luactx_);
     lua_pushcfunction(luactx_, lua_print);
@@ -51,7 +53,7 @@ namespace DeviceSimulator
     lua_getfield(luactx_, -1, "time");
     if (lua_pcall(luactx_, 0, 1, 0) != LUA_OK)
     {
-      LOG_DEBUG("Error calling os.time: {}\n", lua_tostring(luactx_, -1));
+        LOG_DEBUG("Error calling os.time: {}\n", lua_tostring(luactx_, -1));
     }
 
     lua_getglobal(luactx_, "math");
@@ -60,25 +62,25 @@ namespace DeviceSimulator
 
     if (lua_pcall(luactx_, 1, 0, 0) != LUA_OK)
     {
-      LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(luactx_, -1));
+        LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(luactx_, -1));
     }
     LOG_DEBUG("Lua context created\n");
-  }
+}
 
-  VirtualDevice::~VirtualDevice()
-  {
+VirtualDevice::~VirtualDevice()
+{
     LOG_DEBUG("Destroying the device\n");
     lua_close(luactx_);
-  }
+}
 
-  INT VirtualDevice::isdigital(CHAR *pinname)
-  {
+INT VirtualDevice::isdigital(CHAR *pinname)
+{
     (void)pinname;
     return 1;
-  }
+}
 
-  void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
-  {
+void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
+{
     auto &mgr = VirtualContextManager::getInstance();
     dsim_ = dsim;
     instance_ = instance;
@@ -88,50 +90,48 @@ namespace DeviceSimulator
     CoCreateGuid(&guid);
     deviceGUID_ = std::format("{{{0:08X}-{1:04X}-{2:04X}-{3:02X}{4:02X}-"
                               "{5:02X}{6:02X}{7:02X}{8:02X}{9:02X}{10:02X}}}",
-                              guid.Data1, guid.Data2, guid.Data3,
-                              guid.Data4[0], guid.Data4[1], guid.Data4[2],
-                              guid.Data4[3], guid.Data4[4], guid.Data4[5],
-                              guid.Data4[6], guid.Data4[7]);
+                              guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2],
+                              guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
 
     LOG_DEBUG("Setting up the device {} {}\n", deviceID_, deviceGUID_);
     auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(luactx_);
     bool result = scripter->loadScriptFromTextFile("C:\\Dev\\proteus_lua_script\\mcu.lua");
     if (!result)
     {
-      LOG_DEBUG("Failed to load the script\n");
-      return;
+        LOG_DEBUG("Failed to load the script\n");
+        return;
     }
     scripter->execute();
 
     lua_getglobal(luactx_, "device_init");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
     {
-      LOG_DEBUG("Initialization function found\n");
-      if (lua_pcall(luactx_, 0, 0, 0))
-      {
-        const char *err = lua_tostring(luactx_, -1);
-        LOG_DEBUG("Simulation failed with \"{}\"\n", err);
-      }
+        LOG_DEBUG("Initialization function found\n");
+        if (lua_pcall(luactx_, 0, 0, 0))
+        {
+            const char *err = lua_tostring(luactx_, -1);
+            LOG_DEBUG("Simulation failed with \"{}\"\n", err);
+        }
     }
 
     lua_getglobal(luactx_, "timer_callback");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
     {
-      LOG_DEBUG("Timer callback function found\n");
+        LOG_DEBUG("Timer callback function found\n");
     }
 
     lua_getglobal(luactx_, "device_simulate");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
     {
-      LOG_DEBUG("Simulation function found\n");
+        LOG_DEBUG("Simulation function found\n");
     }
 
     lua_getglobal(luactx_, "device_pins");
 
     if (!lua_istable(luactx_, lua_gettop(luactx_)))
     {
-      LOG_DEBUG("Fatal error, no pin assignments found in script\n");
-      return;
+        LOG_DEBUG("Fatal error, no pin assignments found in script\n");
+        return;
     }
 
     int pinsNum = luaL_len(luactx_, -1);
@@ -139,31 +139,31 @@ namespace DeviceSimulator
 
     for (int i = 1; i <= pinsNum; ++i)
     {
-      lua_rawgeti(luactx_, -1, i);
+        lua_rawgeti(luactx_, -1, i);
 
-      if (!lua_istable(luactx_, -1))
-      {
-        LOG_DEBUG("Invalid pin entry at index {}\n", i);
+        if (!lua_istable(luactx_, -1))
+        {
+            LOG_DEBUG("Invalid pin entry at index {}\n", i);
+            lua_pop(luactx_, 1);
+            continue;
+        }
+
+        lua_getfield(luactx_, -1, "name");
+        const char *name = lua_tostring(luactx_, -1);
         lua_pop(luactx_, 1);
-        continue;
-      }
 
-      lua_getfield(luactx_, -1, "name");
-      const char *name = lua_tostring(luactx_, -1);
-      lua_pop(luactx_, 1);
+        lua_getfield(luactx_, -1, "on_time");
+        int on_time = lua_tointeger(luactx_, -1);
+        lua_pop(luactx_, 1);
 
-      lua_getfield(luactx_, -1, "on_time");
-      int on_time = lua_tointeger(luactx_, -1);
-      lua_pop(luactx_, 1);
+        lua_getfield(luactx_, -1, "off_time");
+        int off_time = lua_tointeger(luactx_, -1);
+        lua_pop(luactx_, 1);
 
-      lua_getfield(luactx_, -1, "off_time");
-      int off_time = lua_tointeger(luactx_, -1);
-      lua_pop(luactx_, 1);
-
-      LOG_DEBUG("Pin {}: Name={}, On Time={}, Off Time={}\n", i, name, on_time, off_time);
-      devicePins_.push_back({name, i, on_time, off_time});
-      registerPin(name, i);
-      lua_pop(luactx_, 1);
+        LOG_DEBUG("Pin {}: Name={}, On Time={}, Off Time={}\n", i, name, on_time, off_time);
+        devicePins_.push_back({name, i, on_time, off_time});
+        registerPin(name, i);
+        lua_pop(luactx_, 1);
     }
 
     lua_pop(luactx_, 1);
@@ -195,116 +195,116 @@ namespace DeviceSimulator
     lua_pushinteger(luactx_, WUD);
     lua_setglobal(luactx_, "WUD");
     lua_pushinteger(luactx_, SUD);
-    lua_setglobal(luactx_, "SUD");    
+    lua_setglobal(luactx_, "SUD");
 
-    instance_->getbuspin((CHAR*)"D[4..5]", 2, 2, true);
-  }
+    instance_->getbuspin((CHAR *)"D[4..5]", 2, 2, true);
+}
 
-  void VirtualDevice::runctrl(RUNMODES mode)
-  {
+void VirtualDevice::runctrl(RUNMODES mode)
+{
     switch (mode)
     {
     case RM_BATCH:
 
-      break;
+        break;
     case RM_START:
 
-      break;
+        break;
     case RM_STOP:
 
-      break;
+        break;
     case RM_SUSPEND:
 
-      break;
+        break;
     case RM_ANIMATE:
 
-      break;
+        break;
     case RM_STEPTIME:
 
-      break;
+        break;
     case RM_STEPOVER:
 
-      break;
+        break;
     case RM_STEPINTO:
 
-      break;
+        break;
     case RM_STEPOUT:
 
-      break;
+        break;
     case RM_STEPTO:
 
-      break;
+        break;
     case RM_META:
 
-      break;
+        break;
     case RM_DUMP:
 
-      break;
+        break;
     default:
-      LOG_DEBUG("Unknown mode\n");
-      break;
+        LOG_DEBUG("Unknown mode\n");
+        break;
     }
-  }
+}
 
-  void VirtualDevice::actuate(REALTIME time, ACTIVESTATE newstate)
-  {
-  }
+void VirtualDevice::actuate(REALTIME time, ACTIVESTATE newstate)
+{
+}
 
-  BOOL VirtualDevice::indicate(REALTIME time, ACTIVEDATA *newstate)
-  {
+BOOL VirtualDevice::indicate(REALTIME time, ACTIVEDATA *newstate)
+{
     return true;
-  }
+}
 
-  void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
-  {
+void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
+{
     auto &vinstance = VirtualContextManager::getInstance();
     vinstance.setCurrentDevice(deviceID_);
 
     lua_getglobal(luactx_, "device_simulate");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
     {
-      if (lua_pcall(luactx_, 0, 0, 0))
-      {
-        const char *err = lua_tostring(luactx_, -1);
-        LOG_DEBUG("Simulation failed with \"{}\"\n", err);
-      }
+        if (lua_pcall(luactx_, 0, 0, 0))
+        {
+            const char *err = lua_tostring(luactx_, -1);
+            LOG_DEBUG("Simulation failed with \"{}\"\n", err);
+        }
     }
-  }
+}
 
-  void VirtualDevice::callback(ABSTIME time, EVENTID eventid)
-  {
-  }
+void VirtualDevice::callback(ABSTIME time, EVENTID eventid)
+{
+}
 
-  const lua_State *VirtualContextManager::getDeviceLuaContext(const std::string &id)
-  {
+const lua_State *VirtualContextManager::getDeviceLuaContext(const std::string &id)
+{
     if (devices_.find(id) != devices_.end())
     {
-      VirtualDevice *device = devices_[id];
-      return device->getLuaContext();
+        VirtualDevice *device = devices_[id];
+        return device->getLuaContext();
     }
     return nullptr;
-  }
+}
 
-  const VirtualDevice *VirtualContextManager::getDevice(const std::string &id)
-  {
+const VirtualDevice *VirtualContextManager::getDevice(const std::string &id)
+{
     if (devices_.find(id) != devices_.end())
     {
-      return devices_[id];
+        return devices_[id];
     }
     return nullptr;
-  }
+}
 
-  const VirtualDevice *VirtualContextManager::getDevice()
-  {
+const VirtualDevice *VirtualContextManager::getDevice()
+{
     if (devices_.find(currentDevice_) != devices_.end())
     {
-      return devices_[currentDevice_];
+        return devices_[currentDevice_];
     }
     return nullptr;
-  }
-
-  void VirtualContextManager::registerDevice(std::string id, VirtualDevice &device)
-  {
-    devices_[id] = &device;
-  }
 }
+
+void VirtualContextManager::registerDevice(std::string id, VirtualDevice &device)
+{
+    devices_[id] = &device;
+}
+} // namespace DeviceSimulator

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -5,16 +5,16 @@
 
 namespace DeviceSimulator
 {
-  struct model_pin
-  {
+struct model_pin
+{
     std::string name;
     int number;
     int on_time;
     int off_time;
-  };
+};
 
-  class VirtualDevice : public IDSIMMODEL
-  {
+class VirtualDevice : public IDSIMMODEL
+{
   public:
     VirtualDevice();
     ~VirtualDevice();
@@ -29,22 +29,22 @@ namespace DeviceSimulator
 
     lua_State *getLuaContext() const
     {
-      return luactx_;
+        return luactx_;
     }
 
     IINSTANCE *getInstance() const
     {
-      return instance_;
+        return instance_;
     }
 
     IDSIMPIN *getPin(CHAR *name) const
     {
-      return instance_->getdsimpin(name, true);
+        return instance_->getdsimpin(name, true);
     }
 
     IDSIMCKT *getDSIM() const
     {
-      return dsim_;
+        return dsim_;
     }
 
   private:
@@ -56,15 +56,15 @@ namespace DeviceSimulator
     IDSIMCKT *dsim_;
     std::string deviceID_;
     std::string deviceGUID_;
-  };
+};
 
-  class VirtualContextManager
-  {
+class VirtualContextManager
+{
   public:
     static VirtualContextManager &getInstance()
     {
-      static VirtualContextManager instance;
-      return instance;
+        static VirtualContextManager instance;
+        return instance;
     }
 
     VirtualContextManager(VirtualContextManager const &) = delete;
@@ -76,14 +76,14 @@ namespace DeviceSimulator
     void registerDevice(std::string id, VirtualDevice &device);
     void setCurrentDevice(const std::string &id)
     {
-      currentDevice_ = id;
+        currentDevice_ = id;
     }
 
   private:
-    VirtualContextManager(){};
+    VirtualContextManager() {};
 
     std::string currentDevice_;
     std::map<std::string, VirtualDevice *> devices_;
     lua_State *luactx_;
-  };
-}
+};
+} // namespace DeviceSimulator

--- a/model/include/bind.hpp
+++ b/model/include/bind.hpp
@@ -10,39 +10,39 @@
 #define LTABLE (&lua_istable)
 #define LNONE (NULL)
 
-#define LUA_REGISTER_FUNCTION(ctx, funcName, cFunc) \
-  lua_pushcfunction(ctx, cFunc);                    \
-  lua_setglobal(ctx, funcName);
+#define LUA_REGISTER_FUNCTION(ctx, funcName, cFunc)                                                                    \
+    lua_pushcfunction(ctx, cFunc);                                                                                     \
+    lua_setglobal(ctx, funcName);
 
-#define LUA_REGISTER_METHOD(ctx, methodName, cFunc) \
-  lua_pushcfunction(ctx, cFunc);                    \
-  lua_setfield(ctx, -2, methodName);
+#define LUA_REGISTER_METHOD(ctx, methodName, cFunc)                                                                    \
+    lua_pushcfunction(ctx, cFunc);                                                                                     \
+    lua_setfield(ctx, -2, methodName);
 
 typedef struct
 {
-  const char *lua_func_name;
-  int (*lua_c_api)(lua_State *);
-  int (*args[16])(lua_State *, int index);
+    const char *lua_func_name;
+    int (*lua_c_api)(lua_State *);
+    int (*args[16])(lua_State *, int index);
 } luaBindFunc;
 
 namespace LuaScripting
 {
-  std::vector<char32_t> luaPopChar32Array(lua_State *L, int argPosition = 1);
-  std::u32string luaPopU32String(lua_State *L, int argPosition = 1);
-  std::string luaPopString(lua_State *L, int argPosition = 1);
-  int luaPushU32String(lua_State *L, const std::u32string &str);
-  int luaPushString(lua_State *L, const std::string &str);
-  int luaPushVectorInt(lua_State *L, const std::vector<uint32_t> &vec);
-  int luaPushVectorString32(lua_State *L, const std::vector<std::u32string> &vec);
-  int luaPushVectorString(lua_State *L, const std::vector<std::string> &vec);
+std::vector<char32_t> luaPopChar32Array(lua_State *L, int argPosition = 1);
+std::u32string luaPopU32String(lua_State *L, int argPosition = 1);
+std::string luaPopString(lua_State *L, int argPosition = 1);
+int luaPushU32String(lua_State *L, const std::u32string &str);
+int luaPushString(lua_State *L, const std::string &str);
+int luaPushVectorInt(lua_State *L, const std::vector<uint32_t> &vec);
+int luaPushVectorString32(lua_State *L, const std::vector<std::u32string> &vec);
+int luaPushVectorString(lua_State *L, const std::vector<std::string> &vec);
 
-  void registerDictManagement(lua_State *ctx);
-  void registerKanaProcessor(lua_State *ctx);
-  void registerDictSearch(lua_State *ctx);
-  void registerKanjiSearch(lua_State *L);
-  void registerJlptSearch(lua_State *L);
-  void registerExamplesSearch(lua_State *L);
-  void registerKanjiVgSearch(lua_State *L);
+void registerDictManagement(lua_State *ctx);
+void registerKanaProcessor(lua_State *ctx);
+void registerDictSearch(lua_State *ctx);
+void registerKanjiSearch(lua_State *L);
+void registerJlptSearch(lua_State *L);
+void registerExamplesSearch(lua_State *L);
+void registerKanjiVgSearch(lua_State *L);
 
-  void registerUserNotes(lua_State *L);
-}
+void registerUserNotes(lua_State *L);
+} // namespace LuaScripting

--- a/model/include/executor.hpp
+++ b/model/include/executor.hpp
@@ -4,8 +4,8 @@
 
 namespace LuaScripting
 {
-  class ScriptExecutor
-  {
+class ScriptExecutor
+{
   public:
     ScriptExecutor();
     explicit ScriptExecutor(lua_State *);
@@ -24,7 +24,7 @@ namespace LuaScripting
     void safeExecute(void *curfunc);
 
     lua_State *luactx;
-  };    
-}
+};
+} // namespace LuaScripting
 
 WAKA_API bool runScriptFromTextFile(const char *fileName);

--- a/tools/format.ps1
+++ b/tools/format.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [switch]$Check
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$patterns = @("*.c", "*.cc", "*.cpp", "*.cxx", "*.h", "*.hpp")
+
+$trackedFiles = & git -C $repositoryRoot ls-files -- $patterns
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to enumerate tracked source files."
+}
+
+$sourceFiles = @(
+    $trackedFiles |
+        Where-Object {
+            $_ -notmatch "^(externals/|model/cpp/log/)" -and
+            $_ -ne "model/include/incbin.h"
+        } |
+        Sort-Object -Unique
+)
+
+if ($sourceFiles.Count -eq 0) {
+    throw "No project-owned C or C++ files were found."
+}
+
+$clangFormat = (Get-Command clang-format -ErrorAction Stop).Source
+
+Push-Location $repositoryRoot
+try {
+    if ($Check) {
+        $failedFiles = @()
+        foreach ($sourceFile in $sourceFiles) {
+            & $clangFormat --dry-run --Werror --style=file -- $sourceFile
+            if ($LASTEXITCODE -ne 0) {
+                $failedFiles += $sourceFile
+            }
+        }
+
+        if ($failedFiles.Count -ne 0) {
+            throw "Formatting check failed for: $($failedFiles -join ', ')"
+        }
+
+        Write-Output "Formatting check passed for $($sourceFiles.Count) files."
+    }
+    else {
+        foreach ($sourceFile in $sourceFiles) {
+            & $clangFormat -i --style=file -- $sourceFile
+            if ($LASTEXITCODE -ne 0) {
+                throw "clang-format failed for $sourceFile"
+            }
+        }
+
+        Write-Output "Formatted $($sourceFiles.Count) files."
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
﻿## Summary

- apply the tracked `.clang-format` policy to all 18 project-owned C/C++ files in scope
- add `tools/format.ps1` for formatting and check-only modes
- document the formatting scope and rules in `docs/CODE-STYLE.md`
- make the existing CRLF working-tree policy explicit for C/C++ files, including `.cc` and `.cxx`

## Scope

Third-party and externally maintained code remains excluded: `externals/`, `model/cpp/log/`, and `model/include/incbin.h`.

This PR is intentionally formatting-only. The configured `InsertBraces` rule adds braces to previously unbraced control statements; no behavior change is intended.

## Verification

- `./tools/format.ps1 -Check` ? passed for 18 files
- `git diff --check` ? passed
- reviewed the non-whitespace diff; changes are limited to configured formatting transformations

Closes #46
