### PR TITLE
Allow bundled Lua with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,20 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 set(BasicSettingsFile ${CMAKE_CURRENT_SOURCE_DIR}/wakadll/cpp/settings/basic_settings.yml)
 
-add_subdirectory(externals/Lua)
+function(openvsm_add_bundled_lua)
+  # The pinned Lua project declares CMake 3.1 compatibility. CMake 4 rejects
+  # policy versions below 3.5 and deprecates versions below 3.10. Raise only
+  # the dependency's effective policy minimum and leave the submodule unmodified.
+  if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+  elseif(CMAKE_POLICY_VERSION_MINIMUM VERSION_LESS 3.10)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+  endif()
+
+  add_subdirectory(externals/Lua)
+endfunction()
+
+openvsm_add_bundled_lua()
 add_subdirectory(model/cpp/log)
 add_subdirectory(model)
 add_subdirectory(model/lua)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Generally you need to compile DLL from the sources only if you want to include c
 How to build
 --------------
 
+The CMake build requires CMake 3.21 or newer and supports CMake 4.x.
+
   - Install mingw32 and cygwin for you platform
   - Install Lua 5.3 or higher
   - Clone: https://github.com/Pugnator/openvsm.git openvsm


### PR DESCRIPTION
﻿## Summary

- establish a parent-project policy boundary for the pinned Lua submodule
- raise only Lua's effective policy minimum to 3.10 when the caller has not requested a newer level
- document that the project requires CMake 3.21 or newer and supports CMake 4.x

## Root cause

The pinned Lua 5.4.6 project declares `cmake_minimum_required(VERSION 3.1)`. CMake 4 removed compatibility with policy versions below 3.5, so configuration stopped before OpenVSM targets were generated. Editing the submodule would create a local third-party patch, so the parent now uses CMake's documented `CMAKE_POLICY_VERSION_MINIMUM` boundary immediately around `add_subdirectory(externals/Lua)`.

The effective floor is 3.10 rather than 3.5 because CMake 4 already deprecates compatibility below 3.10. A caller-supplied newer policy floor is preserved.

## Verification

Clean configure with CMake 4.0.0-rc1 and Visual Studio 2022 Win32:

```powershell
cmake --fresh -S . -B .build/issue52-fixed -G "Visual Studio 17 2022" -A Win32
```

Result: configuration and generation completed successfully without the former compatibility error or a policy deprecation warning.

Closes #52
