### PR TITLE
Use the built luac target

### DIFF
--- a/model/lua/CMakeLists.txt
+++ b/model/lua/CMakeLists.txt
@@ -4,7 +4,6 @@ project(LuaBytecode)
 
 set(LUA_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}/../../externals/Lua/src")
 set(LUA_BIN_DIR ${CMAKE_BINARY_DIR}/model/lua)
-set(LUA_EXECUTABLE "${LUA_SRC_DIR}/luac")
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/lua_sources.lst LUA_FILES_LIST)
 string(REPLACE "\n" ";" LUA_FILES_LIST "${LUA_FILES_LIST}")
@@ -30,8 +29,8 @@ foreach(CurrentLuaFile IN LISTS LUA_SINGLE_FILES)
         OUTPUT ${OutputFile}
         COMMENT "Compiling Lua file: ${CurrentLuaFile}"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${TargetDirectory}"
-        COMMAND ${LUA_EXECUTABLE} -o ${OutputFile} ${CurrentLuaFile}
-        DEPENDS ${CurrentLuaFile}
+        COMMAND $<TARGET_FILE:luac> -o ${OutputFile} ${CurrentLuaFile}
+        DEPENDS luac ${CurrentLuaFile}
         VERBATIM
     )    
 endforeach()
@@ -44,6 +43,6 @@ set_source_files_properties(
 )
 
 add_custom_target(LuaBytecode ALL DEPENDS ${ALL_LUA_BYTECODE_FILES} ${EMBEDDED_LUA_LIST})
-add_dependencies(LuaBytecode lua_static)
+add_dependencies(LuaBytecode luac)
 
 include_directories(${LUA_SRC_DIR})


### PR DESCRIPTION
﻿## Summary

- invoke Lua's compiler through the configuration-safe `$<TARGET_FILE:luac>` generator expression
- make each bytecode custom command depend on the `luac` executable target
- make the aggregate `LuaBytecode` target build `luac` instead of only `lua_static`

## Root cause

`model/lua/CMakeLists.txt` constructed `<build>/externals/Lua/src/luac`, but the Visual Studio multi-configuration generator writes the executable to configuration-specific locations such as `<build>/externals/Lua/Debug/luac.exe`. The custom target also depended only on `lua_static`, so nothing required the compiler executable to exist before bytecode generation.

CMake now resolves the executable path for the active configuration and schedules the correct target first.

## Verification

Using CMake 4.0.0-rc1, Visual Studio 2022, Win32, and the local Proteus SDK:

- clean `LuaBytecode` target build ? Debug passed
- clean `LuaBytecode` target build ? Release passed
- generated Debug and Release `bus.luac` files validated with their respective `luac -l`
- full OpenVSM build ? Debug passed
- full OpenVSM build ? Release passed
- `./tools/format.ps1 -Check` ? passed for 18 C/C++ files

Pre-existing MSVC option and local vcpkg PowerShell warnings remain outside this change.

Closes #42
