### PR TITLE
Use configuration-aware MSVC flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ How to build
 --------------
 
 The CMake build requires CMake 3.21 or newer and supports CMake 4.x.
+Select the required 32-bit MSVC target with the Visual Studio generator option
+`-A Win32`; MSVC does not use the GCC `-m32` option.
 
   - Install mingw32 and cygwin for you platform
   - Install Lua 5.3 or higher

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -9,32 +9,8 @@ if(NOT CMAKE_GENERATOR)
     set(CMAKE_GENERATOR "MinGW Makefiles" CACHE INTERNAL "" FORCE)
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
-if (_cpp_latest_flag_supported)
-  add_compile_options("/std:c++latest")
-  add_compile_options("/EHsc")
-endif()
-
 set(BUILD_SHARED_LIBS ON)
 option(BUILD_TESTS "Enable building tests" OFF)
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions(-DOPENVSM_DEBUG)
-    set(CMAKE_CXX_FLAGS_DEBUG  "-ggdb -Og")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Og")    
-else()
-    add_definitions(-DOPENVSM_RELEASE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast")    
-endif()
-
-add_definitions(-DOPENVSM_VERSION="${OPENVSM_VERSION}")
-
-set(CFLAGS "${CFLAGS} ${OPTIM}")
-set(CXXFLAGS "${CXXFLAGS} ${OPTIM}")
 
 set(SRCDIR cpp)
 
@@ -62,11 +38,21 @@ set(CPPSRC
 
 
 add_library(VSM_DLL SHARED ${CPPSRC})
-set_property(TARGET VSM_DLL PROPERTY POSITION_INDEPENDENT_CODE 1)
-set_target_properties(VSM_DLL PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(VSM_DLL PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+  POSITION_INDEPENDENT_CODE ON
+)
 
-target_compile_options(VSM_DLL PRIVATE -m32)
-target_link_options(VSM_DLL PRIVATE -m32)
+target_compile_definitions(VSM_DLL PRIVATE
+  OPENVSM_VERSION="${OPENVSM_VERSION}"
+  $<$<CONFIG:Debug>:OPENVSM_DEBUG>
+  $<$<NOT:$<CONFIG:Debug>>:OPENVSM_RELEASE>
+)
+
+target_compile_options(VSM_DLL PRIVATE
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/EHsc>
+)
 
 set_target_properties(VSM_DLL PROPERTIES PREFIX "")
 set_target_properties(VSM_DLL PROPERTIES OUTPUT_NAME "openvsm")
@@ -94,7 +80,6 @@ target_link_libraries(VSM_DLL PRIVATE
 lua_static
 tinyLog
 )
-
 if(BUILD_TESTS)
   add_executable(native_bus_test
     tests/native_bus_test.cc


### PR DESCRIPTION
﻿## Summary

- replace `CMAKE_BUILD_TYPE` branching with configuration-aware target definitions
- rely on CMake's standard Debug/Release optimization flags instead of injecting GNU options globally
- enable `/EHsc` only for MSVC C++ compilation
- let CMake infer the C++ linker language
- remove ignored `-m32` compile/link options and document Visual Studio's `-A Win32` selection

## Root cause

Visual Studio is a multi-configuration generator, so `CMAKE_BUILD_TYPE` is empty during configuration. The old logic therefore defined `OPENVSM_RELEASE` for Debug and appended GNU `-Ofast`/`-m32` options to MSVC. It also forced C linking for a C++ implementation.

The DLL now owns its C++ standard, definitions, and compiler-specific option. Debug and non-Debug definitions are selected per generated configuration.

## Verification

Using CMake 4.0.0-rc1, Visual Studio 2022, Win32, and the local Proteus SDK:

- full Debug build passed
- full Release build passed
- generated Debug project contains `OPENVSM_DEBUG`
- generated non-Debug configurations contain `OPENVSM_RELEASE`
- generated project contains no `m32` option
- generated C++ compile settings enable synchronous exception handling
- previous MSVC/LINK ignored-option warnings are gone
- `./tools/format.ps1 -Check` passed for 18 files

Because #60 is still under review, validation used an out-of-tree copy of the generated `luac.exe` at the old expected path. That test artifact was removed and is not part of this PR.

Closes #51
