### PR TITLE
Balance pin registration Lua stacks

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -105,4 +105,9 @@ if(BUILD_TESTS)
   endif()
 
   add_test(NAME native_bus COMMAND native_bus_test)
+
+  add_executable(pin_registration_stack_test tests/pin_registration_stack_test.cc)
+  target_include_directories(pin_registration_stack_test PRIVATE ${SRCDIR})
+  target_link_libraries(pin_registration_stack_test PRIVATE VSM_DLL lua_static)
+  add_test(NAME pin_registration_stack COMMAND pin_registration_stack_test)
 endif()

--- a/model/cpp/luabind/device/pin.cc
+++ b/model/cpp/luabind/device/pin.cc
@@ -1,6 +1,8 @@
 #include <log/log.hpp>
 #include "model.hpp"
 #include "lua.hpp"
+#include "lua_stack_guard.hpp"
+#include "luabind/device/pin.hpp"
 
 namespace DeviceSimulator
 {
@@ -257,18 +259,24 @@ static const luaL_Reg VsmPinMethodsLib[] = {{"set", l_pin_set},
                                             {"polarity", l_pin_polarity},
                                             {NULL, NULL}};
 
+void registerPinLibrary(lua_State *luaContext, const char *name, int number)
+{
+    LuaScripting::LuaStackGuard stackGuard(luaContext);
+    luaL_newlib(luaContext, VsmPinMethodsLib);
+
+    // Set the pin number as a field in the library
+    lua_pushnumber(luaContext, number);
+    lua_setfield(luaContext, -2, "pinNumber");
+
+    lua_pushstring(luaContext, name);
+    lua_setfield(luaContext, -2, "pinName");
+    // Set the library as a global variable with the given name
+    lua_setglobal(luaContext, name);
+}
+
 void VirtualDevice::registerPin(const char *name, int num)
 {
     LOG_DEBUG("Registering pin {}-{}\n", name, num);
-    luaL_newlib(luactx_, VsmPinMethodsLib);
-
-    // Set the pin number as a field in the library
-    lua_pushnumber(luactx_, num);
-    lua_setfield(luactx_, -2, "pinNumber");
-
-    lua_pushstring(luactx_, name);
-    lua_setfield(luactx_, -2, "pinName");
-    // Set the library as a global variable with the given name
-    lua_setglobal(luactx_, name);
+    registerPinLibrary(luactx_, name, num);
 }
 } // namespace DeviceSimulator

--- a/model/cpp/luabind/device/pin.hpp
+++ b/model/cpp/luabind/device/pin.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <lua.hpp>
+
+namespace DeviceSimulator
+{
+void registerPinLibrary(lua_State *luaContext, const char *name, int number);
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/lua_stack_guard.hpp
+++ b/model/cpp/luabind/lua_stack_guard.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cassert>
+#include <lua.hpp>
+
+namespace LuaScripting
+{
+class LuaStackGuard
+{
+  public:
+    explicit LuaStackGuard(lua_State *state) : state_(state), top_(lua_gettop(state))
+    {
+    }
+
+    ~LuaStackGuard()
+    {
+        assert(lua_gettop(state_) == top_);
+    }
+
+    LuaStackGuard(const LuaStackGuard &) = delete;
+    LuaStackGuard &operator=(const LuaStackGuard &) = delete;
+
+    int top() const
+    {
+        return top_;
+    }
+
+  private:
+    lua_State *state_;
+    int top_;
+};
+} // namespace LuaScripting

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -1,6 +1,7 @@
 #include <log/log.hpp>
 #include <format>
 #include "model.hpp"
+#include "lua_stack_guard.hpp"
 #include "lua_script_executor.hpp"
 #include <windows.h>
 #include <combaseapi.h>
@@ -46,6 +47,7 @@ VirtualDevice::VirtualDevice()
         throw std::runtime_error("Failed to create a new Lua state");
     }
 
+    LuaScripting::LuaStackGuard stackGuard(luactx_);
     luaL_openlibs(luactx_);
     lua_pushcfunction(luactx_, lua_print);
     lua_setglobal(luactx_, "print");
@@ -64,6 +66,7 @@ VirtualDevice::VirtualDevice()
     {
         LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(luactx_, -1));
     }
+    lua_settop(luactx_, stackGuard.top());
     LOG_DEBUG("Lua context created\n");
 }
 
@@ -81,6 +84,7 @@ INT VirtualDevice::isdigital(CHAR *pinname)
 
 void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
 {
+    LuaScripting::LuaStackGuard stackGuard(luactx_);
     auto &mgr = VirtualContextManager::getInstance();
     dsim_ = dsim;
     instance_ = instance;
@@ -99,9 +103,11 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     if (!result)
     {
         LOG_DEBUG("Failed to load the script\n");
+        lua_settop(luactx_, stackGuard.top());
         return;
     }
     scripter->execute();
+    lua_settop(luactx_, stackGuard.top());
 
     lua_getglobal(luactx_, "device_init");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
@@ -111,7 +117,12 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
         {
             const char *err = lua_tostring(luactx_, -1);
             LOG_DEBUG("Simulation failed with \"{}\"\n", err);
+            lua_pop(luactx_, 1);
         }
+    }
+    else
+    {
+        lua_pop(luactx_, 1);
     }
 
     lua_getglobal(luactx_, "timer_callback");
@@ -119,18 +130,21 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     {
         LOG_DEBUG("Timer callback function found\n");
     }
+    lua_pop(luactx_, 1);
 
     lua_getglobal(luactx_, "device_simulate");
     if (lua_isfunction(luactx_, lua_gettop(luactx_)))
     {
         LOG_DEBUG("Simulation function found\n");
     }
+    lua_pop(luactx_, 1);
 
     lua_getglobal(luactx_, "device_pins");
 
     if (!lua_istable(luactx_, lua_gettop(luactx_)))
     {
         LOG_DEBUG("Fatal error, no pin assignments found in script\n");
+        lua_pop(luactx_, 1);
         return;
     }
 

--- a/model/tests/pin_registration_stack_test.cc
+++ b/model/tests/pin_registration_stack_test.cc
@@ -1,0 +1,54 @@
+#include <string>
+#include <vector>
+#include "luabind/device/pin.hpp"
+#include "model.hpp"
+#include <lua.hpp>
+
+int main()
+{
+    {
+        DeviceSimulator::VirtualDevice device;
+        if (lua_gettop(device.getLuaContext()) != 0)
+        {
+            return 1;
+        }
+    }
+
+    lua_State *luaContext = luaL_newstate();
+    if (!luaContext)
+    {
+        return 2;
+    }
+
+    for (int number = 1; number <= 8; ++number)
+    {
+        const int originalTop = lua_gettop(luaContext);
+        const std::string name = "PIN" + std::to_string(number);
+
+        DeviceSimulator::registerPinLibrary(luaContext, name.c_str(), number);
+        if (lua_gettop(luaContext) != originalTop)
+        {
+            lua_close(luaContext);
+            return 3;
+        }
+
+        lua_getglobal(luaContext, name.c_str());
+        const bool isTable = lua_istable(luaContext, -1);
+        lua_getfield(luaContext, -1, "pinNumber");
+        const bool hasNumber = lua_tointeger(luaContext, -1) == number;
+        lua_pop(luaContext, 1);
+        lua_getfield(luaContext, -1, "pinName");
+        const char *registeredName = lua_tostring(luaContext, -1);
+        const bool hasName = registeredName && name == registeredName;
+        lua_settop(luaContext, originalTop);
+
+        if (!isTable || !hasNumber || !hasName)
+        {
+            lua_close(luaContext);
+            return 4;
+        }
+    }
+
+    lua_close(luaContext);
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary

- balance the Lua values used to seed `math.randomseed` during device construction
- pop callback-discovery globals and initialization errors explicitly during setup
- restore the entry stack when script loading/execution fails
- add debug-only stack guards around construction, setup, and pin-library registration
- expose the internal pin-library registration primitive for a focused CTest regression
- add a regression that constructs a device and registers eight pins with zero stack delta

## Root cause

The previously reported extra pop after `lua_setglobal` had already been removed from the current `feature/v0.7` base. However, construction still retained the `os` table, seed value, and `math` table, while setup retained discovered callback values. Those leaked values had hidden the old over-pop and left later Lua API calls dependent on unrelated stack contents.

Each boundary now enters and exits at the same stack top. Debug builds assert that invariant.

## Verification

With CMake 4.0.0-rc1, Visual Studio 2022 Win32, the local Proteus SDK, and `BUILD_TESTS=ON`:

- `pin_registration_stack_test` built successfully
- CTest passed: 1/1
- constructor stack top verified as zero
- eight pin libraries registered with zero net stack delta
- registered names and numbers verified
- `./tools/format.ps1 -Check` passed for all 21 tracked C/C++ files

Until #60 lands, the build used a generated `luac.exe` copy at the old expected path. It was removed with the build tree.

Closes #43
