### PR TITLE
Keep ScriptExecutor state non-owning

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -110,4 +110,12 @@ if(BUILD_TESTS)
   target_include_directories(pin_registration_stack_test PRIVATE ${SRCDIR})
   target_link_libraries(pin_registration_stack_test PRIVATE VSM_DLL lua_static)
   add_test(NAME pin_registration_stack COMMAND pin_registration_stack_test)
+
+  add_executable(script_executor_ownership_test
+    tests/script_executor_ownership_test.cc
+    ${SRCDIR}/luabind/lua_script_executor.cc
+  )
+  target_include_directories(script_executor_ownership_test PRIVATE ${SRCDIR}/luabind)
+  target_link_libraries(script_executor_ownership_test PRIVATE lua_static tinyLog)
+  add_test(NAME script_executor_ownership COMMAND script_executor_ownership_test)
 endif()

--- a/model/cpp/luabind/lua_script_executor.cc
+++ b/model/cpp/luabind/lua_script_executor.cc
@@ -1,84 +1,96 @@
 #include "lua_script_executor.hpp"
 #include "log/log.hpp"
 #include "lua_bind.hpp"
+#include <cstddef>
 #include <memory>
+#include <stdexcept>
 #include "lua.hpp"
 
 namespace LuaScripting
 {
 ScriptExecutor::ScriptExecutor(lua_State *ctx)
 {
-    luactx = ctx;
+    if (!ctx)
+    {
+        throw std::invalid_argument("ScriptExecutor requires a Lua state");
+    }
+    luaContext_ = ctx;
+}
+
+bool ScriptExecutor::captureLuaError(const char *operation)
+{
+    const char *errorMessage = lua_tostring(luaContext_, -1);
+    lastError_ = errorMessage ? errorMessage : "Unknown Lua error";
+    LOG_DEBUG("{}: {}\n", operation, lastError_);
+    lua_pop(luaContext_, 1);
+    return false;
 }
 
 bool ScriptExecutor::loadScriptFromString(const char *script)
 {
-    int result = luaL_loadstring(luactx, script);
+    lastError_.clear();
+    int result = luaL_loadstring(luaContext_, script);
     if (result != LUA_OK)
     {
-        const char *errorMessage = lua_tostring(luactx, -1);
-        LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
-        return false;
+        return captureLuaError("Lua string load error");
     }
     return true;
 }
 
 bool ScriptExecutor::loadScriptFromTextFile(const char *fileName)
 {
-    int result = luaL_loadfile(luactx, fileName);
+    lastError_.clear();
+    int result = luaL_loadfile(luaContext_, fileName);
     if (result != LUA_OK)
     {
-        const char *errorMessage = lua_tostring(luactx, -1);
-        LOG_DEBUG("Lua Load Error: {}\n", errorMessage);
-        return false;
+        return captureLuaError("Lua file load error");
     }
     return true;
 }
 
 bool ScriptExecutor::loadScriptFromBinaryFile(const char *fileName)
 {
+    (void)fileName;
+    lastError_ = "Binary Lua file loading is not implemented";
     return false;
 }
 
-void ScriptExecutor::loadScriptFromResource(const unsigned char *start, const unsigned char *end)
+bool ScriptExecutor::loadScriptFromResource(const unsigned char *start, const unsigned char *end)
 {
-    lua_State *L = luactx;
-    int bytecodeSize = end - start;
-
-    if (luaL_loadbuffer(L, reinterpret_cast<const char *>(start), bytecodeSize, "embedded_lua") == 0)
+    lastError_.clear();
+    if (!start || !end || end <= start)
     {
-        int result = lua_pcall(L, 0, 0, 0);
-        if (result != 0)
-        {
-            const char *errorMsg = lua_tostring(L, -1);
-        }
-    }
-    else
-    {
-        const char *errorMsg = lua_tostring(L, -1);
+        lastError_ = "Lua resource range is empty or invalid";
+        return false;
     }
 
-    lua_close(L);
+    const std::size_t bytecodeSize = static_cast<std::size_t>(end - start);
+    if (luaL_loadbuffer(luaContext_, reinterpret_cast<const char *>(start), bytecodeSize, "embedded_lua") != LUA_OK)
+    {
+        return captureLuaError("Lua resource load error");
+    }
+
+    if (lua_pcall(luaContext_, 0, 0, 0) != LUA_OK)
+    {
+        return captureLuaError("Lua resource execution error");
+    }
+
+    return true;
 }
 
-bool ScriptExecutor::isFuncExists(const char *funcName)
+bool ScriptExecutor::execute()
 {
-    lua_getglobal(luactx, funcName);
-    if (lua_isfunction(luactx, lua_gettop(this->luactx)))
+    lastError_.clear();
+    if (lua_pcall(luaContext_, 0, 0, 0) != LUA_OK)
     {
-        return true;
+        return captureLuaError("Lua execution error");
     }
-    return false;
+    return true;
 }
 
-void ScriptExecutor::execute()
+const std::string &ScriptExecutor::lastError() const noexcept
 {
-    int result = lua_pcall(luactx, 0, 0, 0);
-    if (result != LUA_OK)
-    {
-        const char *errorMessage = lua_tostring(luactx, -1);
-        LOG_DEBUG("Lua Error: {}\n", errorMessage);
-    }
+    return lastError_;
 }
 } // namespace LuaScripting
 
@@ -86,6 +98,5 @@ bool runScriptFromTextFile(lua_State *ctx, const char *fileName)
 {
     auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(ctx);
     bool result = scripter->loadScriptFromTextFile(fileName);
-    scripter->execute();
-    return result;
+    return result && scripter->execute();
 }

--- a/model/cpp/luabind/lua_script_executor.hpp
+++ b/model/cpp/luabind/lua_script_executor.hpp
@@ -1,21 +1,29 @@
 #pragma once
 #include <lua.hpp>
+#include <string>
 
 namespace LuaScripting
 {
 class ScriptExecutor
 {
   public:
-    ScriptExecutor(lua_State *ctx);
+    // The caller retains ownership of the Lua state and must keep it alive for
+    // the lifetime of this executor.
+    explicit ScriptExecutor(lua_State *ctx);
+    ~ScriptExecutor() = default;
 
     bool loadScriptFromString(const char *script);
     bool loadScriptFromTextFile(const char *fileName);
     bool loadScriptFromBinaryFile(const char *fileName);
-    void loadScriptFromResource(const unsigned char *start, const unsigned char *end);
-    void execute();
+    bool loadScriptFromResource(const unsigned char *start, const unsigned char *end);
+    bool execute();
+
+    const std::string &lastError() const noexcept;
 
   private:
-    bool isFuncExists(const char *funcName);
-    lua_State *luactx;
+    bool captureLuaError(const char *operation);
+
+    lua_State *luaContext_;
+    std::string lastError_;
 };
 } // namespace LuaScripting

--- a/model/tests/script_executor_ownership_test.cc
+++ b/model/tests/script_executor_ownership_test.cc
@@ -1,0 +1,61 @@
+#include "lua_script_executor.hpp"
+#include <lua.hpp>
+#include <string>
+
+int main()
+{
+    lua_State *luaContext = luaL_newstate();
+    if (!luaContext)
+    {
+        return 1;
+    }
+    luaL_openlibs(luaContext);
+
+    const int originalTop = lua_gettop(luaContext);
+    {
+        LuaScripting::ScriptExecutor executor(luaContext);
+
+        const std::string resource = "resource_value = 41";
+        const auto *start = reinterpret_cast<const unsigned char *>(resource.data());
+        if (!executor.loadScriptFromResource(start, start + resource.size()))
+        {
+            lua_close(luaContext);
+            return 2;
+        }
+        if (lua_gettop(luaContext) != originalTop)
+        {
+            lua_close(luaContext);
+            return 3;
+        }
+
+        const std::string syntaxError = "this is not valid Lua";
+        start = reinterpret_cast<const unsigned char *>(syntaxError.data());
+        if (executor.loadScriptFromResource(start, start + syntaxError.size()) || executor.lastError().empty() ||
+            lua_gettop(luaContext) != originalTop)
+        {
+            lua_close(luaContext);
+            return 4;
+        }
+
+        const std::string runtimeError = "error('resource failure')";
+        start = reinterpret_cast<const unsigned char *>(runtimeError.data());
+        if (executor.loadScriptFromResource(start, start + runtimeError.size()) ||
+            executor.lastError().find("resource failure") == std::string::npos || lua_gettop(luaContext) != originalTop)
+        {
+            lua_close(luaContext);
+            return 5;
+        }
+    }
+
+    if (luaL_dostring(luaContext, "resource_value = resource_value + 1") != LUA_OK)
+    {
+        lua_close(luaContext);
+        return 6;
+    }
+    lua_getglobal(luaContext, "resource_value");
+    const bool stateIsUsable = lua_tointeger(luaContext, -1) == 42;
+    lua_pop(luaContext, 1);
+
+    lua_close(luaContext);
+    return stateIsUsable ? 0 : 7;
+}


### PR DESCRIPTION
﻿## Summary

- make `ScriptExecutor` explicitly non-owning and reject null state pointers
- remove the `lua_close` call from resource loading
- return success/failure from resource loading and execution
- retain useful Lua error text in `lastError()` and pop every error object
- avoid executing an error object when text-file loading fails
- remove the unused stack-leaking function lookup helper
- add an ownership/error-stack regression test

## Root cause

`ScriptExecutor` receives a caller-owned `lua_State*`, but `loadScriptFromResource()` unconditionally closed it. The owning `VirtualDevice` retained a dangling pointer and would later use and close the same state again. Load and execution errors also remained on the Lua stack.

The executor now borrows the state for its lifetime and never destroys it. All failure paths capture and pop the Lua error object.

## Verification

With CMake 4.0.0-rc1 and Visual Studio 2022 Win32:

- `script_executor_ownership_test` built successfully
- CTest passed: 1/1
- resource source loaded and executed successfully
- syntax and runtime failures returned false, preserved useful messages, and restored the original stack top
- the Lua state remained usable after `ScriptExecutor` destruction
- the test closed the state once at the end
- the full Debug `VSM_DLL` target built successfully
- `./tools/format.ps1 -Check` passed for all 19 tracked C/C++ files

The full DLL check used the temporary generated-path workaround for #60; no artifact entered this PR.

Closes #47
