### PR TITLE
Resolve model scripts from component configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ For a manual Visual Studio configuration, select the same target with
 
 Build outputs are written below `build/vs2022-win32/bin/<configuration>`.
 
+Each Proteus model selects its script with the component's `LUA` string property,
+for example `LUA=device.lua`. Relative values are resolved beneath `LUAVSM`;
+absolute paths are used directly. Paths may contain spaces and `LUAVSM` does not
+need a trailing slash. A missing property, script root, or readable script keeps
+that model out of simulation.
+
 # License
 ----
 

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -27,6 +27,7 @@ set(DLL_SRC
   ${SRCDIR}/dllmain.cc
   ${SRCDIR}/model.cc
   ${SRCDIR}/luabind/device/bus.cc
+  ${SRCDIR}/model_script_path.cc
   ${SRCDIR}/luabind/device/pin.cc
   ${SRCDIR}/luabind/lua_facade.cc
   ${SRCDIR}/luabind/lua_script_executor.cc
@@ -133,4 +134,16 @@ if(BUILD_TESTS)
   target_include_directories(model_authorization_test PRIVATE ${SRCDIR})
   target_link_libraries(model_authorization_test PRIVATE VSM_DLL lua_static)
   add_test(NAME model_authorization COMMAND model_authorization_test)
+
+  add_executable(model_script_path_test
+    tests/model_script_path_test.cc
+    ${SRCDIR}/model_script_path.cc
+  )
+  target_include_directories(model_script_path_test PRIVATE ${SRCDIR})
+  target_link_libraries(model_script_path_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(model_script_path_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME model_script_path COMMAND model_script_path_test)
 endif()

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -1,8 +1,10 @@
 #include <log/log.hpp>
 #include <cassert>
+#include <cstdlib>
 #include <format>
 #include "model.hpp"
 #include "lua_stack_guard.hpp"
+#include "model_script_path.hpp"
 #include "lua_script_executor.hpp"
 #include <windows.h>
 #include <combaseapi.h>
@@ -92,6 +94,7 @@ INT VirtualDevice::isdigital(CHAR *pinname)
 
 void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
 {
+    modelReady_ = false;
     LuaScripting::LuaStackGuard stackGuard(luactx_);
     auto &mgr = VirtualContextManager::getInstance();
     dsim_ = dsim;
@@ -106,8 +109,21 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
                               guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
 
     LOG_DEBUG("Setting up the device {} {}\n", deviceID_, deviceGUID_);
+    constexpr char scriptProperty[] = "LUA";
+    const char *configuredScript = instance_->getstrval(const_cast<char *>(scriptProperty));
+    const char *scriptRoot = std::getenv("LUAVSM");
+    const auto scriptPath = resolveModelScriptPath(configuredScript == nullptr ? "" : configuredScript,
+                                                   scriptRoot == nullptr ? "" : scriptRoot);
+    if (!scriptPath)
+    {
+        LOG_DEBUG("Failed to select the model script: {}\n", scriptPath.error);
+        return;
+    }
+
+    const auto scriptPathText = scriptPath.path.string();
+    LOG_DEBUG("Loading model script {}\n", scriptPathText);
     auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(luactx_);
-    bool result = scripter->loadScriptFromTextFile("C:\\Dev\\proteus_lua_script\\mcu.lua");
+    bool result = scripter->loadScriptFromTextFile(scriptPathText.c_str());
     if (!result)
     {
         LOG_DEBUG("Failed to load the script\n");
@@ -224,6 +240,7 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
         LOG_DEBUG("Failed to register model buses\n");
         return;
     }
+    modelReady_ = true;
 }
 
 void VirtualDevice::runctrl(RUNMODES mode)
@@ -286,7 +303,7 @@ void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
     (void)time;
     (void)mode;
     const int originalStackTop = lua_gettop(luactx_);
-    if (!simulationCallbackEnabled_)
+    if (!modelReady_ || !simulationCallbackEnabled_)
     {
         assert(lua_gettop(luactx_) == originalStackTop);
         return;

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -58,6 +58,7 @@ class VirtualDevice : public IDSIMMODEL
     std::string deviceID_;
     std::string deviceGUID_;
     bool simulationCallbackEnabled_ = true;
+    bool modelReady_ = false;
 };
 
 class VirtualContextManager

--- a/model/cpp/model_script_path.cc
+++ b/model/cpp/model_script_path.cc
@@ -1,0 +1,40 @@
+#include "model_script_path.hpp"
+
+#include <fstream>
+
+namespace DeviceSimulator
+{
+ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, std::string_view scriptRoot)
+{
+    if (configuredScript.empty())
+    {
+        return {{}, "the model's LUA property is empty"};
+    }
+
+    std::filesystem::path path{configuredScript};
+    if (path.is_relative())
+    {
+        if (scriptRoot.empty())
+        {
+            return {{}, "LUAVSM is not set for the relative script path '" + path.string() + "'"};
+        }
+        path = std::filesystem::path{scriptRoot} / path;
+    }
+
+    path = path.lexically_normal();
+
+    std::error_code fileError;
+    if (!std::filesystem::is_regular_file(path, fileError))
+    {
+        return {path, "the model script is not a readable regular file: '" + path.string() + "'"};
+    }
+
+    std::ifstream script{path, std::ios::binary};
+    if (!script.is_open())
+    {
+        return {path, "the model script cannot be opened for reading: '" + path.string() + "'"};
+    }
+
+    return {path, {}};
+}
+} // namespace DeviceSimulator

--- a/model/cpp/model_script_path.hpp
+++ b/model/cpp/model_script_path.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace DeviceSimulator
+{
+struct ModelScriptPath
+{
+    std::filesystem::path path;
+    std::string error;
+
+    explicit operator bool() const
+    {
+        return error.empty();
+    }
+};
+
+ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, std::string_view scriptRoot);
+} // namespace DeviceSimulator

--- a/model/tests/model_script_path_test.cc
+++ b/model/tests/model_script_path_test.cc
@@ -1,0 +1,105 @@
+#include "model_script_path.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <lua.hpp>
+
+namespace
+{
+class TemporaryDirectory
+{
+  public:
+    TemporaryDirectory()
+    {
+        const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = std::filesystem::temp_directory_path() / ("openvsm model scripts " + std::to_string(suffix));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TemporaryDirectory()
+    {
+        std::error_code ignored;
+        std::filesystem::remove_all(path_, ignored);
+    }
+
+    const std::filesystem::path &path() const
+    {
+        return path_;
+    }
+
+  private:
+    std::filesystem::path path_;
+};
+
+bool writeScript(const std::filesystem::path &path, int modelId)
+{
+    std::ofstream script{path};
+    script << "model_id = " << modelId << '\n';
+    return script.good();
+}
+
+bool loadAndCheck(lua_State *lua, const std::filesystem::path &path, int expectedModelId)
+{
+    if (luaL_dofile(lua, path.string().c_str()) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_pop(lua, 1);
+        return false;
+    }
+
+    lua_getglobal(lua, "model_id");
+    const bool matches = lua_isinteger(lua, -1) && lua_tointeger(lua, -1) == expectedModelId;
+    lua_pop(lua, 1);
+    return matches;
+}
+} // namespace
+
+int main()
+{
+    TemporaryDirectory scripts;
+    const auto firstScript = scripts.path() / "first model.lua";
+    const auto secondScript = scripts.path() / "second model.lua";
+    if (!writeScript(firstScript, 1) || !writeScript(secondScript, 2))
+    {
+        std::cerr << "Failed to create the test scripts\n";
+        return 1;
+    }
+
+    const auto first = DeviceSimulator::resolveModelScriptPath("first model.lua", scripts.path().string());
+    const auto second = DeviceSimulator::resolveModelScriptPath(secondScript.string(), "unused root");
+    if (!first || !second || first.path != firstScript.lexically_normal() ||
+        second.path != secondScript.lexically_normal())
+    {
+        std::cerr << "Failed to resolve distinct relative and absolute model scripts\n";
+        return 1;
+    }
+
+    auto *lua = luaL_newstate();
+    if (lua == nullptr)
+    {
+        std::cerr << "Failed to create a Lua state\n";
+        return 1;
+    }
+
+    const bool scriptsLoaded = loadAndCheck(lua, first.path, 1) && loadAndCheck(lua, second.path, 2);
+    lua_close(lua);
+    if (!scriptsLoaded)
+    {
+        std::cerr << "Failed to load the independently selected model scripts\n";
+        return 1;
+    }
+
+    const auto noRoot = DeviceSimulator::resolveModelScriptPath("relative.lua", {});
+    const auto missing = DeviceSimulator::resolveModelScriptPath("missing.lua", scripts.path().string());
+    if (noRoot || missing)
+    {
+        std::cerr << "Invalid script configuration was accepted\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- read each Proteus component's `LUA` property instead of loading a developer-specific path
- resolve relative script names beneath `LUAVSM`, while accepting absolute paths and roots without a trailing slash
- reject missing or unreadable scripts and keep an unconfigured model out of simulation
- document the script-selection contract and add a path/loading regression test

## Validation
- `cmake -S . -B .build/model-script-path -A Win32 -DBUILD_TESTS=ON`
- `cmake --build .build/model-script-path --config Debug --target model_script_path_test`
- `ctest --test-dir .build/model-script-path -C Debug --output-on-failure -R model_script_path`
- built `luac`, copied it to the legacy generated location as a test-only shim, then ran `cmake --build .build/model-script-path --config Debug --target VSM_DLL`
- `tools/format.ps1 -Check`

The build still reports the known legacy MSVC flag warnings fixed separately by #61 and the local vcpkg `pwsh.exe` warning.

Closes #50