### PR TITLE
Dispatch Lua lifecycle callbacks

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DLL_SRC
   ${SRCDIR}/luabind/device/bus.cc
   ${SRCDIR}/model_script_path.cc
   ${SRCDIR}/luabind/device/pin.cc
+  ${SRCDIR}/luabind/lua_callback.cc
   ${SRCDIR}/luabind/lua_facade.cc
   ${SRCDIR}/luabind/lua_script_executor.cc
   ${SRCDIR}/luabind/bytecode_loader.cc
@@ -146,4 +147,16 @@ if(BUILD_TESTS)
   endif()
 
   add_test(NAME model_script_path COMMAND model_script_path_test)
+
+  add_executable(lua_lifecycle_test
+    tests/lua_lifecycle_test.cc
+    ${SRCDIR}/luabind/lua_callback.cc
+  )
+  target_include_directories(lua_lifecycle_test PRIVATE ${SRCDIR})
+  target_link_libraries(lua_lifecycle_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(lua_lifecycle_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME lua_lifecycle COMMAND lua_lifecycle_test)
 endif()

--- a/model/cpp/luabind/lua_callback.cc
+++ b/model/cpp/luabind/lua_callback.cc
@@ -1,0 +1,38 @@
+#include "lua_callback.hpp"
+
+#include <utility>
+
+namespace LuaScripting
+{
+CallbackResult invokeCallback(lua_State *lua, const char *name, std::initializer_list<lua_Integer> arguments)
+{
+    if (lua == nullptr)
+    {
+        return {CallbackStatus::failed, "Lua state is not available"};
+    }
+
+    const int stackTop = lua_gettop(lua);
+    lua_getglobal(lua, name);
+    if (!lua_isfunction(lua, -1))
+    {
+        lua_settop(lua, stackTop);
+        return {CallbackStatus::notDefined, {}};
+    }
+
+    for (const auto argument : arguments)
+    {
+        lua_pushinteger(lua, argument);
+    }
+
+    if (lua_pcall(lua, static_cast<int>(arguments.size()), 0, 0) != LUA_OK)
+    {
+        const char *message = lua_tostring(lua, -1);
+        std::string error = message == nullptr ? "unknown Lua error" : message;
+        lua_settop(lua, stackTop);
+        return {CallbackStatus::failed, std::move(error)};
+    }
+
+    lua_settop(lua, stackTop);
+    return {CallbackStatus::succeeded, {}};
+}
+} // namespace LuaScripting

--- a/model/cpp/luabind/lua_callback.hpp
+++ b/model/cpp/luabind/lua_callback.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <initializer_list>
+#include <string>
+
+#include <lua.hpp>
+
+namespace LuaScripting
+{
+enum class CallbackStatus
+{
+    notDefined,
+    succeeded,
+    failed
+};
+
+struct CallbackResult
+{
+    CallbackStatus status;
+    std::string error;
+};
+
+CallbackResult invokeCallback(lua_State *lua, const char *name, std::initializer_list<lua_Integer> arguments = {});
+} // namespace LuaScripting

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -5,6 +5,7 @@
 #include "model.hpp"
 #include "lua_stack_guard.hpp"
 #include "model_script_path.hpp"
+#include "lua_callback.hpp"
 #include "lua_script_executor.hpp"
 #include <windows.h>
 #include <combaseapi.h>
@@ -133,36 +134,6 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     scripter->execute();
     lua_settop(luactx_, stackGuard.top());
 
-    lua_getglobal(luactx_, "device_init");
-    if (lua_isfunction(luactx_, lua_gettop(luactx_)))
-    {
-        LOG_DEBUG("Initialization function found\n");
-        if (lua_pcall(luactx_, 0, 0, 0))
-        {
-            const char *err = lua_tostring(luactx_, -1);
-            LOG_DEBUG("Simulation failed with \"{}\"\n", err);
-            lua_pop(luactx_, 1);
-        }
-    }
-    else
-    {
-        lua_pop(luactx_, 1);
-    }
-
-    lua_getglobal(luactx_, "timer_callback");
-    if (lua_isfunction(luactx_, lua_gettop(luactx_)))
-    {
-        LOG_DEBUG("Timer callback function found\n");
-    }
-    lua_pop(luactx_, 1);
-
-    lua_getglobal(luactx_, "device_simulate");
-    if (lua_isfunction(luactx_, lua_gettop(luactx_)))
-    {
-        LOG_DEBUG("Simulation function found\n");
-    }
-    lua_pop(luactx_, 1);
-
     lua_getglobal(luactx_, "device_pins");
 
     if (!lua_istable(luactx_, lua_gettop(luactx_)))
@@ -239,6 +210,17 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     {
         LOG_DEBUG("Failed to register model buses\n");
         return;
+    }
+
+    mgr.setCurrentDevice(deviceID_);
+    const auto initialization = LuaScripting::invokeCallback(luactx_, "device_init");
+    if (initialization.status == LuaScripting::CallbackStatus::succeeded)
+    {
+        LOG_DEBUG("Device initialization completed\n");
+    }
+    else if (initialization.status == LuaScripting::CallbackStatus::failed)
+    {
+        LOG_DEBUG("Device initialization failed with \"{}\"\n", initialization.error);
     }
     modelReady_ = true;
 }
@@ -332,6 +314,20 @@ void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
 
 void VirtualDevice::callback(ABSTIME time, EVENTID eventid)
 {
+    if (!modelReady_)
+    {
+        return;
+    }
+
+    auto &vinstance = VirtualContextManager::getInstance();
+    vinstance.setCurrentDevice(deviceID_);
+
+    const auto callback = LuaScripting::invokeCallback(
+        luactx_, "timer_callback", {static_cast<lua_Integer>(time), static_cast<lua_Integer>(eventid)});
+    if (callback.status == LuaScripting::CallbackStatus::failed)
+    {
+        LOG_DEBUG("Timer callback failed with \"{}\"\n", callback.error);
+    }
 }
 
 const lua_State *VirtualContextManager::getDeviceLuaContext(const std::string &id)

--- a/model/tests/lua_lifecycle_test.cc
+++ b/model/tests/lua_lifecycle_test.cc
@@ -1,0 +1,108 @@
+#include "luabind/lua_callback.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace
+{
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+
+bool checkLifecycleEvents(lua_State *lua)
+{
+    lua_getglobal(lua, "events");
+    if (!lua_istable(lua, -1) || lua_rawlen(lua, -1) != 3)
+    {
+        lua_pop(lua, 1);
+        return false;
+    }
+
+    lua_rawgeti(lua, -1, 1);
+    const bool initializedFirst = std::string{lua_tostring(lua, -1)} == "init";
+    lua_pop(lua, 1);
+    lua_rawgeti(lua, -1, 2);
+    const bool timeForwarded = lua_tointeger(lua, -1) == 0x123456789LL;
+    lua_pop(lua, 1);
+    lua_rawgeti(lua, -1, 3);
+    const bool eventForwarded = lua_tointeger(lua, -1) == 73;
+    lua_pop(lua, 2);
+    return initializedFirst && timeForwarded && eventForwarded;
+}
+} // namespace
+
+int main()
+{
+    auto *lua = luaL_newstate();
+    if (lua == nullptr)
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+
+    const char *lifecycleScript = R"(
+        events = {}
+        function device_init()
+            assert(A ~= nil)
+            assert(TSTATE == 1)
+            table.insert(events, "init")
+        end
+        function timer_callback(time, event_id)
+            table.insert(events, time)
+            table.insert(events, event_id)
+        end
+    )";
+    if (!run(lua, lifecycleScript))
+    {
+        lua_close(lua);
+        return 1;
+    }
+
+    lua_newtable(lua);
+    lua_setglobal(lua, "A");
+    lua_pushinteger(lua, 1);
+    lua_setglobal(lua, "TSTATE");
+
+    const int lifecycleStackTop = lua_gettop(lua);
+    const auto initialized = LuaScripting::invokeCallback(lua, "device_init");
+    const auto timer = LuaScripting::invokeCallback(lua, "timer_callback", {0x123456789LL, 73});
+    if (initialized.status != LuaScripting::CallbackStatus::succeeded ||
+        timer.status != LuaScripting::CallbackStatus::succeeded || lua_gettop(lua) != lifecycleStackTop ||
+        !checkLifecycleEvents(lua))
+    {
+        std::cerr << "Lifecycle callbacks were not dispatched in order with their arguments\n";
+        lua_close(lua);
+        return 1;
+    }
+
+    lua_pushstring(lua, "stack sentinel");
+    const int errorStackTop = lua_gettop(lua);
+    if (!run(lua, "function timer_callback() error('timer exploded') end"))
+    {
+        lua_close(lua);
+        return 1;
+    }
+    const auto failed = LuaScripting::invokeCallback(lua, "timer_callback", {1, 2});
+    const auto missing = LuaScripting::invokeCallback(lua, "not_defined");
+    if (failed.status != LuaScripting::CallbackStatus::failed ||
+        failed.error.find("timer exploded") == std::string::npos ||
+        missing.status != LuaScripting::CallbackStatus::notDefined || lua_gettop(lua) != errorStackTop ||
+        std::string{lua_tostring(lua, -1)} != "stack sentinel")
+    {
+        std::cerr << "Callback errors or missing functions corrupted the Lua stack\n";
+        lua_close(lua);
+        return 1;
+    }
+
+    lua_pop(lua, 1);
+    lua_close(lua);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- initialize Lua models only after their pin globals and VSM state constants are registered
- forward Proteus timer callbacks to `timer_callback(time, event_id)` with the full integer values
- preserve the Lua stack around absent, successful, and failing lifecycle callbacks
- make the current device explicit before lifecycle code can access pin bindings
- add lifecycle-order, argument-forwarding, and error-isolation regression coverage

## Validation
- `cmake -S . -B .build/lua-lifecycle -A Win32 -DBUILD_TESTS=ON`
- `cmake --build .build/lua-lifecycle --config Debug --target lua_lifecycle_test`
- `ctest --test-dir .build/lua-lifecycle -C Debug --output-on-failure -R lua_lifecycle`
- built `luac`, copied it to the legacy generated location as a test-only shim, then ran `cmake --build .build/lua-lifecycle --config Debug --target VSM_DLL`
- `tools/format.ps1 -Check`

The build still reports the known legacy MSVC flag warnings fixed separately by #61 and the local vcpkg `pwsh.exe` warning.

Closes #48