### PR TITLE
Apply Lua pin transition timings

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -30,6 +30,7 @@ set(DLL_SRC
   ${SRCDIR}/model_script_path.cc
   ${SRCDIR}/luabind/device/pin.cc
   ${SRCDIR}/luabind/lua_callback.cc
+  ${SRCDIR}/luabind/device/pin_timing.cc
   ${SRCDIR}/luabind/lua_facade.cc
   ${SRCDIR}/luabind/lua_script_executor.cc
   ${SRCDIR}/luabind/bytecode_loader.cc
@@ -159,4 +160,19 @@ if(BUILD_TESTS)
   endif()
 
   add_test(NAME lua_lifecycle COMMAND lua_lifecycle_test)
+
+  add_executable(pin_timing_test
+    tests/pin_timing_test.cc
+    ${SRCDIR}/luabind/device/pin_timing.cc
+  )
+  target_include_directories(pin_timing_test PRIVATE
+    ${SRCDIR}
+    ${CMAKE_SOURCE_DIR}/externals/sdk
+  )
+  target_link_libraries(pin_timing_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(pin_timing_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME pin_timing COMMAND pin_timing_test)
 endif()

--- a/model/cpp/luabind/device/pin.cc
+++ b/model/cpp/luabind/device/pin.cc
@@ -1,5 +1,6 @@
 #include <log/log.hpp>
 #include "model.hpp"
+#include "pin_timing.hpp"
 #include "lua.hpp"
 #include "lua_stack_guard.hpp"
 #include "luabind/device/pin.hpp"
@@ -24,12 +25,31 @@ model_pin getPinSelf(lua_State *L)
     int pinNumber = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
+    lua_pushstring(L, "onTime");
+    lua_gettable(L, -lua_gettop(L));
+    const auto onTime = static_cast<RELTIME>(luaL_checkinteger(L, -1));
+    lua_pop(L, 1);
+
+    lua_pushstring(L, "offTime");
+    lua_gettable(L, -lua_gettop(L));
+    const auto offTime = static_cast<RELTIME>(luaL_checkinteger(L, -1));
+    lua_pop(L, 1);
+
     model_pin pin;
     pin.name = pinName;
     pin.number = pinNumber;
-    pin.on_time = 0;
-    pin.off_time = 0;
+    pin.on_time = onTime;
+    pin.off_time = offTime;
     return pin;
+}
+
+static void setPinState(const model_pin &pin, STATE state)
+{
+    auto device = VirtualContextManager::getInstance().getDevice();
+    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    ABSTIME time = 0;
+    device->getDSIM()->systime(&time);
+    pinInstance->setstate(time, transitionDelay(state, pin), state);
 }
 
 static int l_pin_set(lua_State *L)
@@ -39,13 +59,7 @@ static int l_pin_set(lua_State *L)
     int level = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
-
-    auto dsim = device->getDSIM();
-    DOUBLE at;
-    dsim->sysvar(&at, DSIMTIMENOW);
-    pinInstance->setstate(at, 10000, level == 1 ? TSTATE : FSTATE);
+    setPinState(pin, level == 1 ? TSTATE : FSTATE);
     return 0;
 }
 
@@ -56,13 +70,7 @@ static int l_pin_set_state(lua_State *L)
     STATE state = (STATE)luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
-
-    auto dsim = device->getDSIM();
-    DOUBLE at;
-    dsim->sysvar(&at, DSIMTIMENOW);
-    pinInstance->setstate(at, 10000, state);
+    setPinState(pin, state);
     return 0;
 }
 
@@ -80,18 +88,14 @@ static int l_pin_get(lua_State *L)
 static int l_pin_set_hi(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
-    pinInstance->setstate(TSTATE);
+    setPinState(pin, TSTATE);
     return 0;
 }
 
 static int l_pin_set_lo(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
-    pinInstance->setstate(FSTATE);
+    setPinState(pin, FSTATE);
     return 0;
 }
 
@@ -100,7 +104,19 @@ static int l_pin_invert(lua_State *L)
     auto pin = getPinSelf(L);
     auto device = VirtualContextManager::getInstance().getDevice();
     auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
-    pinInstance->invert();
+    const auto state = pinInstance->istate();
+    if (ishigh(state))
+    {
+        setPinState(pin, FSTATE);
+    }
+    else if (islow(state))
+    {
+        setPinState(pin, TSTATE);
+    }
+    else
+    {
+        pinInstance->invert();
+    }
     return 0;
 }
 
@@ -259,24 +275,37 @@ static const luaL_Reg VsmPinMethodsLib[] = {{"set", l_pin_set},
                                             {"polarity", l_pin_polarity},
                                             {NULL, NULL}};
 
-void registerPinLibrary(lua_State *luaContext, const char *name, int number)
+namespace
+{
+void registerPinLibrary(lua_State *luaContext, const model_pin &pin)
 {
     LuaScripting::LuaStackGuard stackGuard(luaContext);
     luaL_newlib(luaContext, VsmPinMethodsLib);
 
-    // Set the pin number as a field in the library
-    lua_pushnumber(luaContext, number);
+    lua_pushinteger(luaContext, pin.number);
     lua_setfield(luaContext, -2, "pinNumber");
 
-    lua_pushstring(luaContext, name);
+    lua_pushstring(luaContext, pin.name.c_str());
     lua_setfield(luaContext, -2, "pinName");
-    // Set the library as a global variable with the given name
-    lua_setglobal(luaContext, name);
+
+    lua_pushinteger(luaContext, pin.on_time);
+    lua_setfield(luaContext, -2, "onTime");
+
+    lua_pushinteger(luaContext, pin.off_time);
+    lua_setfield(luaContext, -2, "offTime");
+
+    lua_setglobal(luaContext, pin.name.c_str());
+}
+} // namespace
+
+void registerPinLibrary(lua_State *luaContext, const char *name, int number)
+{
+    registerPinLibrary(luaContext, model_pin{name, number, 0, 0});
 }
 
-void VirtualDevice::registerPin(const char *name, int num)
+void VirtualDevice::registerPin(const model_pin &pin)
 {
-    LOG_DEBUG("Registering pin {}-{}\n", name, num);
-    registerPinLibrary(luactx_, name, num);
+    LOG_DEBUG("Registering pin {}-{}\n", pin.name, pin.number);
+    registerPinLibrary(luactx_, pin);
 }
 } // namespace DeviceSimulator

--- a/model/cpp/luabind/device/pin_timing.cc
+++ b/model/cpp/luabind/device/pin_timing.cc
@@ -1,0 +1,60 @@
+#include "pin_timing.hpp"
+
+#include "model.hpp"
+
+namespace DeviceSimulator
+{
+namespace
+{
+RELTIME readTiming(lua_State *lua, int tableIndex, const char *field)
+{
+    lua_getfield(lua, tableIndex, field);
+    int isInteger = 0;
+    const auto timing = lua_tointegerx(lua, -1, &isInteger);
+    lua_pop(lua, 1);
+    return isInteger == 0 ? 0 : normalizePinTiming(timing);
+}
+} // namespace
+
+RELTIME normalizePinTiming(lua_Integer timing)
+{
+    return timing < 0 ? 0 : static_cast<RELTIME>(timing);
+}
+
+model_pin readPinDefinition(lua_State *lua, int tableIndex, int pinNumber)
+{
+    tableIndex = lua_absindex(lua, tableIndex);
+
+    lua_getfield(lua, tableIndex, "name");
+    const char *name = lua_tostring(lua, -1);
+    model_pin pin{name == nullptr ? "" : name, pinNumber, 0, 0};
+    lua_pop(lua, 1);
+
+    pin.on_time = readTiming(lua, tableIndex, "on_time");
+    pin.off_time = readTiming(lua, tableIndex, "off_time");
+    return pin;
+}
+
+RELTIME transitionDelay(STATE state, const model_pin &pin)
+{
+    // TSTATE and FSTATE are Proteus logical-state tokens rather than ordinary
+    // polarity values, so handle them before inspecting the polarity bits.
+    if (state == TSTATE)
+    {
+        return pin.on_time;
+    }
+    if (state == FSTATE)
+    {
+        return pin.off_time;
+    }
+    if (ishigh(state))
+    {
+        return pin.on_time;
+    }
+    if (islow(state))
+    {
+        return pin.off_time;
+    }
+    return 0;
+}
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/device/pin_timing.hpp
+++ b/model/cpp/luabind/device/pin_timing.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <lua.hpp>
+#include <vsm.hpp>
+
+namespace DeviceSimulator
+{
+struct model_pin;
+
+RELTIME normalizePinTiming(lua_Integer timing);
+model_pin readPinDefinition(lua_State *lua, int tableIndex, int pinNumber);
+RELTIME transitionDelay(STATE state, const model_pin &pin);
+} // namespace DeviceSimulator

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -6,6 +6,7 @@
 #include "lua_stack_guard.hpp"
 #include "model_script_path.hpp"
 #include "lua_callback.hpp"
+#include "luabind/device/pin_timing.hpp"
 #include "lua_script_executor.hpp"
 #include <windows.h>
 #include <combaseapi.h>
@@ -157,21 +158,10 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
             continue;
         }
 
-        lua_getfield(luactx_, -1, "name");
-        const char *name = lua_tostring(luactx_, -1);
-        lua_pop(luactx_, 1);
-
-        lua_getfield(luactx_, -1, "on_time");
-        int on_time = lua_tointeger(luactx_, -1);
-        lua_pop(luactx_, 1);
-
-        lua_getfield(luactx_, -1, "off_time");
-        int off_time = lua_tointeger(luactx_, -1);
-        lua_pop(luactx_, 1);
-
-        LOG_DEBUG("Pin {}: Name={}, On Time={}, Off Time={}\n", i, name, on_time, off_time);
-        devicePins_.push_back({name, i, on_time, off_time});
-        registerPin(name, i);
+        auto pin = readPinDefinition(luactx_, -1, i);
+        LOG_DEBUG("Pin {}: Name={}, On Time={}, Off Time={}\n", i, pin.name, pin.on_time, pin.off_time);
+        devicePins_.push_back(pin);
+        registerPin(pin);
         lua_pop(luactx_, 1);
     }
 

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -2,6 +2,8 @@
 #include <vsm.hpp>
 #include <lua.hpp>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace DeviceSimulator
 {
@@ -9,8 +11,8 @@ struct model_pin
 {
     std::string name;
     int number;
-    int on_time;
-    int off_time;
+    RELTIME on_time;
+    RELTIME off_time;
 };
 
 class VirtualDevice : public IDSIMMODEL
@@ -48,7 +50,7 @@ class VirtualDevice : public IDSIMMODEL
     }
 
   private:
-    void registerPin(const char *name, int num);
+    void registerPin(const model_pin &pin);
     bool registerBuses();
 
     std::vector<model_pin> devicePins_;

--- a/model/tests/pin_timing_test.cc
+++ b/model/tests/pin_timing_test.cc
@@ -1,0 +1,50 @@
+#include "luabind/device/pin_timing.hpp"
+#include "model.hpp"
+
+#include <iostream>
+
+int main()
+{
+    auto *lua = luaL_newstate();
+    if (lua == nullptr)
+    {
+        return 1;
+    }
+
+    if (luaL_dostring(lua, "return {name='Q', on_time=125000, off_time=375000}") != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+
+    const auto pin = DeviceSimulator::readPinDefinition(lua, -1, 3);
+    lua_pop(lua, 1);
+    if (pin.name != "Q" || pin.number != 3 || DeviceSimulator::transitionDelay(TSTATE, pin) != 125000 ||
+        DeviceSimulator::transitionDelay(SHI, pin) != 125000 ||
+        DeviceSimulator::transitionDelay(FSTATE, pin) != 375000 ||
+        DeviceSimulator::transitionDelay(SLO, pin) != 375000 || DeviceSimulator::transitionDelay(FLT, pin) != 0)
+    {
+        std::cerr << "Pin transition delays were not parsed or selected correctly\n";
+        lua_close(lua);
+        return 1;
+    }
+
+    if (luaL_dostring(lua, "return {name='A', on_time=-1, off_time='invalid'}") != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+
+    const auto invalid = DeviceSimulator::readPinDefinition(lua, -1, 1);
+    lua_pop(lua, 1);
+    lua_close(lua);
+    if (invalid.on_time != 0 || invalid.off_time != 0)
+    {
+        std::cerr << "Invalid pin timings were not normalized to zero\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- preserve each Lua pin's parsed `on_time` and `off_time` in its registered binding
- schedule `set`, `setstate`, `hi`, `lo`, and binary `invert` operations with the appropriate configured delay
- use `on_time` for logical/high states, `off_time` for logical/low states, and zero delay for floating or undefined direct assignments
- normalize missing, non-integer, and negative timing values to zero
- add regression coverage with deliberately different on/off delays and invalid values

## Validation
- `cmake -S . -B .build/pin-timing -A Win32 -DBUILD_TESTS=ON`
- `cmake --build .build/pin-timing --config Debug --target pin_timing_test`
- `ctest --test-dir .build/pin-timing -C Debug --output-on-failure -R pin_timing`
- built `luac`, copied it to the legacy generated location as a test-only shim, then ran `cmake --build .build/pin-timing --config Debug --target VSM_DLL`
- `tools/format.ps1 -Check`

The build still reports the known legacy MSVC flag warnings fixed separately by #61 and the local vcpkg `pwsh.exe` warning.

Closes #44