### PR TITLE
Add Lua callbacks for pins and buses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ zero-based, and drive values must fit the declared width. The optional
 corresponding SDK behavior. Call methods with Lua's object syntax, such as
 `D:drive(0x5a)` or `D:drivebit(0, SHI)`.
 
+Pin objects support `pin:onchange(function)` and `pin:onstate(state, function)`.
+Bus objects similarly support `bus:onchange(function)` and
+`bus:onvalue(value, function)`. A callback receives simulation time, simulation
+mode, and the new pin state or bus value. It runs only after the registered
+object changes; a callback that raises an error is disabled without affecting
+the other callbacks.
+
+```lua
+function device_init()
+    A:onstate(SHI, function(time, mode, state)
+        print("A became high", time, mode, state)
+    end)
+end
+```
+
 # Installation
 --------------
 

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -28,6 +28,7 @@ set(DLL_SRC
   ${SRCDIR}/model.cc
   ${SRCDIR}/luabind/device/bus.cc
   ${SRCDIR}/model_script_path.cc
+  ${SRCDIR}/luabind/device/lua_event_dispatcher.cc
   ${SRCDIR}/luabind/device/pin.cc
   ${SRCDIR}/luabind/lua_callback.cc
   ${SRCDIR}/luabind/device/pin_timing.cc
@@ -89,6 +90,7 @@ if(BUILD_TESTS)
   add_executable(native_bus_test
     tests/native_bus_test.cc
     ${SRCDIR}/luabind/device/bus.cc
+    ${SRCDIR}/luabind/device/lua_event_dispatcher.cc
   )
   target_include_directories(native_bus_test PRIVATE
     ${SRCDIR}
@@ -193,4 +195,19 @@ if(BUILD_TESTS)
     NAME lua_test_ic
     COMMAND lua_test_ic_test "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/test_ic.lua"
   )
+
+  add_executable(object_callback_test
+    tests/object_callback_test.cc
+    ${SRCDIR}/luabind/device/lua_event_dispatcher.cc
+  )
+  target_include_directories(object_callback_test PRIVATE
+    ${SRCDIR}
+    ${CMAKE_SOURCE_DIR}/externals/sdk
+  )
+  target_link_libraries(object_callback_test PRIVATE lua_static tinyLog)
+  if(MSVC)
+    target_compile_options(object_callback_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME object_callback COMMAND object_callback_test)
 endif()

--- a/model/cpp/luabind/device/bus.cc
+++ b/model/cpp/luabind/device/bus.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include "model.hpp"
 #include "bus.hpp"
+#include "lua_event_dispatcher.hpp"
 #include "lua.hpp"
 
 namespace DeviceSimulator
@@ -260,12 +261,17 @@ bool readBusDefinition(lua_State *lua, int tableIndex, BusDefinition &definition
     return true;
 }
 
-void registerBusObject(lua_State *lua, const BusDefinition &definition, IBUSPIN *bus, IDSIMCKT *dsim)
+void registerBusObject(lua_State *lua, const BusDefinition &definition, IBUSPIN *bus, IDSIMCKT *dsim,
+                       LuaEventDispatcher *dispatcher)
 {
     bus->settiming(definition.on_time, definition.off_time, definition.tristate_time);
     bus->setstates(definition.on_state, definition.off_state, definition.tristate_state);
 
     luaL_newlib(lua, busMethods);
+    if (dispatcher != nullptr)
+    {
+        attachBusCallbackApi(lua, -1, bus, dispatcher);
+    }
     lua_pushlightuserdata(lua, bus);
     lua_setfield(lua, -2, nativeBusField);
     lua_pushlightuserdata(lua, dsim);
@@ -316,7 +322,7 @@ bool VirtualDevice::registerBuses()
             return false;
         }
 
-        registerBusObject(luactx_, definition, bus, dsim_);
+        registerBusObject(luactx_, definition, bus, dsim_, eventDispatcher_.get());
         lua_pop(luactx_, 1);
     }
 

--- a/model/cpp/luabind/device/bus.hpp
+++ b/model/cpp/luabind/device/bus.hpp
@@ -7,6 +7,8 @@
 
 namespace DeviceSimulator
 {
+class LuaEventDispatcher;
+
 struct BusDefinition
 {
     std::string name;
@@ -22,5 +24,6 @@ struct BusDefinition
 };
 
 bool readBusDefinition(lua_State *lua, int tableIndex, BusDefinition &definition, std::string &error);
-void registerBusObject(lua_State *lua, const BusDefinition &definition, IBUSPIN *bus, IDSIMCKT *dsim);
+void registerBusObject(lua_State *lua, const BusDefinition &definition, IBUSPIN *bus, IDSIMCKT *dsim,
+                       LuaEventDispatcher *dispatcher = nullptr);
 } // namespace DeviceSimulator

--- a/model/cpp/luabind/device/lua_event_dispatcher.cc
+++ b/model/cpp/luabind/device/lua_event_dispatcher.cc
@@ -1,0 +1,241 @@
+#include <log/log.hpp>
+
+#include "lua_event_dispatcher.hpp"
+
+#include <cstdint>
+#include <limits>
+
+namespace DeviceSimulator
+{
+namespace
+{
+constexpr const char *dispatcherField = "__event_dispatcher";
+constexpr const char *nativePinField = "__callback_pin";
+constexpr const char *nativeBusField = "__callback_bus";
+
+template <typename Pointer> Pointer getPointer(lua_State *lua, const char *field)
+{
+    luaL_checktype(lua, 1, LUA_TTABLE);
+    lua_getfield(lua, 1, field);
+    auto pointer = static_cast<Pointer>(lua_touserdata(lua, -1));
+    lua_pop(lua, 1);
+    if (pointer == nullptr)
+    {
+        luaL_error(lua, "invalid callback object");
+    }
+    return pointer;
+}
+
+LuaEventDispatcher *getDispatcher(lua_State *lua)
+{
+    return getPointer<LuaEventDispatcher *>(lua, dispatcherField);
+}
+
+STATE checkedState(lua_State *lua, int argument)
+{
+    const auto value = luaL_checkinteger(lua, argument);
+    if (value < (std::numeric_limits<INT>::min)() || value > (std::numeric_limits<INT>::max)())
+    {
+        luaL_argerror(lua, argument, "state is outside the SDK integer range");
+    }
+    return static_cast<STATE>(value);
+}
+
+UINT getBusWidth(lua_State *lua)
+{
+    lua_getfield(lua, 1, "width");
+    const auto value = luaL_checkinteger(lua, -1);
+    lua_pop(lua, 1);
+    if (value < 1 || value > MAXBUSBITS)
+    {
+        luaL_argerror(lua, 1, "invalid native bus width");
+    }
+    return static_cast<UINT>(value);
+}
+
+DWORD checkedBusValue(lua_State *lua, int argument)
+{
+    const auto value = luaL_checkinteger(lua, argument);
+    const auto width = getBusWidth(lua);
+    const std::uint64_t maximum =
+        width == MAXBUSBITS ? (std::numeric_limits<DWORD>::max)() : (std::uint64_t{1} << width) - 1;
+    if (value < 0 || static_cast<std::uint64_t>(value) > maximum)
+    {
+        luaL_argerror(lua, argument, "callback value does not fit the bus width");
+    }
+    return static_cast<DWORD>(value);
+}
+
+int pinOnChange(lua_State *lua)
+{
+    luaL_checktype(lua, 2, LUA_TFUNCTION);
+    getDispatcher(lua)->addPinCallback(getPointer<IDSIMPIN *>(lua, nativePinField), 2);
+    return 0;
+}
+
+int pinOnState(lua_State *lua)
+{
+    const auto state = checkedState(lua, 2);
+    luaL_checktype(lua, 3, LUA_TFUNCTION);
+    getDispatcher(lua)->addPinCallback(getPointer<IDSIMPIN *>(lua, nativePinField), 3, state);
+    return 0;
+}
+
+int busOnChange(lua_State *lua)
+{
+    luaL_checktype(lua, 2, LUA_TFUNCTION);
+    getDispatcher(lua)->addBusCallback(getPointer<IBUSPIN *>(lua, nativeBusField), 2);
+    return 0;
+}
+
+int busOnValue(lua_State *lua)
+{
+    const auto value = checkedBusValue(lua, 2);
+    luaL_checktype(lua, 3, LUA_TFUNCTION);
+    getDispatcher(lua)->addBusCallback(getPointer<IBUSPIN *>(lua, nativeBusField), 3, value);
+    return 0;
+}
+
+void setPointer(lua_State *lua, int tableIndex, const char *field, void *pointer)
+{
+    lua_pushlightuserdata(lua, pointer);
+    lua_setfield(lua, tableIndex, field);
+}
+} // namespace
+
+LuaEventDispatcher::LuaEventDispatcher(lua_State *lua, IDSIMMODEL *model) : lua_(lua), model_(model)
+{
+}
+
+LuaEventDispatcher::~LuaEventDispatcher()
+{
+    for (auto &callback : pinCallbacks_)
+    {
+        disable(callback.functionReference);
+    }
+    for (auto &callback : busCallbacks_)
+    {
+        disable(callback.functionReference);
+    }
+}
+
+void LuaEventDispatcher::addPinCallback(IDSIMPIN *pin, int functionIndex, std::optional<STATE> expectedState)
+{
+    functionIndex = lua_absindex(lua_, functionIndex);
+    lua_pushvalue(lua_, functionIndex);
+    const int reference = luaL_ref(lua_, LUA_REGISTRYINDEX);
+    pinCallbacks_.push_back({pin, reference, expectedState, pin->istate()});
+    pin->sethandler(model_, &IDSIMMODEL::simulate);
+}
+
+void LuaEventDispatcher::addBusCallback(IBUSPIN *bus, int functionIndex, std::optional<DWORD> expectedValue)
+{
+    functionIndex = lua_absindex(lua_, functionIndex);
+    lua_pushvalue(lua_, functionIndex);
+    const int reference = luaL_ref(lua_, LUA_REGISTRYINDEX);
+    busCallbacks_.push_back({bus, reference, expectedValue, bus->getbusvalue()});
+    bus->sethandler(model_, &IDSIMMODEL::simulate);
+}
+
+bool LuaEventDispatcher::invoke(int functionReference, ABSTIME time, DSIMMODES mode, lua_Integer value)
+{
+    const int stackTop = lua_gettop(lua_);
+    lua_rawgeti(lua_, LUA_REGISTRYINDEX, functionReference);
+    lua_pushinteger(lua_, time);
+    lua_pushinteger(lua_, mode);
+    lua_pushinteger(lua_, value);
+    if (lua_pcall(lua_, 3, 0, 0) != LUA_OK)
+    {
+        const char *message = lua_tostring(lua_, -1);
+        LOG_DEBUG("Lua object callback failed with \"{}\"\n", message == nullptr ? "unknown Lua error" : message);
+        lua_settop(lua_, stackTop);
+        return false;
+    }
+    lua_settop(lua_, stackTop);
+    return true;
+}
+
+void LuaEventDispatcher::disable(int &functionReference)
+{
+    if (functionReference != LUA_NOREF)
+    {
+        luaL_unref(lua_, LUA_REGISTRYINDEX, functionReference);
+        functionReference = LUA_NOREF;
+    }
+}
+
+void LuaEventDispatcher::dispatch(ABSTIME time, DSIMMODES mode)
+{
+    const auto pinCount = pinCallbacks_.size();
+    for (std::size_t index = 0; index < pinCount; ++index)
+    {
+        auto &callback = pinCallbacks_[index];
+        if (callback.functionReference == LUA_NOREF)
+        {
+            continue;
+        }
+        const auto state = callback.pin->istate();
+        if (state == callback.lastState)
+        {
+            continue;
+        }
+        callback.lastState = state;
+        if (callback.expectedState.has_value() && callback.expectedState.value() != state)
+        {
+            continue;
+        }
+        const int reference = callback.functionReference;
+        if (!invoke(reference, time, mode, state))
+        {
+            disable(pinCallbacks_[index].functionReference);
+        }
+    }
+
+    const auto busCount = busCallbacks_.size();
+    for (std::size_t index = 0; index < busCount; ++index)
+    {
+        auto &callback = busCallbacks_[index];
+        if (callback.functionReference == LUA_NOREF)
+        {
+            continue;
+        }
+        const auto value = callback.bus->getbusvalue();
+        if (value == callback.lastValue)
+        {
+            continue;
+        }
+        callback.lastValue = value;
+        if (callback.expectedValue.has_value() && callback.expectedValue.value() != value)
+        {
+            continue;
+        }
+        const int reference = callback.functionReference;
+        if (!invoke(reference, time, mode, value))
+        {
+            disable(busCallbacks_[index].functionReference);
+        }
+    }
+}
+
+void attachPinCallbackApi(lua_State *lua, int tableIndex, IDSIMPIN *pin, LuaEventDispatcher *dispatcher)
+{
+    tableIndex = lua_absindex(lua, tableIndex);
+    setPointer(lua, tableIndex, nativePinField, pin);
+    setPointer(lua, tableIndex, dispatcherField, dispatcher);
+    lua_pushcfunction(lua, pinOnChange);
+    lua_setfield(lua, tableIndex, "onchange");
+    lua_pushcfunction(lua, pinOnState);
+    lua_setfield(lua, tableIndex, "onstate");
+}
+
+void attachBusCallbackApi(lua_State *lua, int tableIndex, IBUSPIN *bus, LuaEventDispatcher *dispatcher)
+{
+    tableIndex = lua_absindex(lua, tableIndex);
+    setPointer(lua, tableIndex, nativeBusField, bus);
+    setPointer(lua, tableIndex, dispatcherField, dispatcher);
+    lua_pushcfunction(lua, busOnChange);
+    lua_setfield(lua, tableIndex, "onchange");
+    lua_pushcfunction(lua, busOnValue);
+    lua_setfield(lua, tableIndex, "onvalue");
+}
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/device/lua_event_dispatcher.hpp
+++ b/model/cpp/luabind/device/lua_event_dispatcher.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <lua.hpp>
+#include <vsm.hpp>
+
+namespace DeviceSimulator
+{
+class LuaEventDispatcher
+{
+  public:
+    LuaEventDispatcher(lua_State *lua, IDSIMMODEL *model);
+    ~LuaEventDispatcher();
+
+    LuaEventDispatcher(const LuaEventDispatcher &) = delete;
+    LuaEventDispatcher &operator=(const LuaEventDispatcher &) = delete;
+
+    void addPinCallback(IDSIMPIN *pin, int functionIndex, std::optional<STATE> expectedState = std::nullopt);
+    void addBusCallback(IBUSPIN *bus, int functionIndex, std::optional<DWORD> expectedValue = std::nullopt);
+    void dispatch(ABSTIME time, DSIMMODES mode);
+
+  private:
+    struct PinCallback
+    {
+        IDSIMPIN *pin;
+        int functionReference;
+        std::optional<STATE> expectedState;
+        STATE lastState;
+    };
+
+    struct BusCallback
+    {
+        IBUSPIN *bus;
+        int functionReference;
+        std::optional<DWORD> expectedValue;
+        DWORD lastValue;
+    };
+
+    bool invoke(int functionReference, ABSTIME time, DSIMMODES mode, lua_Integer value);
+    void disable(int &functionReference);
+
+    lua_State *lua_;
+    IDSIMMODEL *model_;
+    std::vector<PinCallback> pinCallbacks_;
+    std::vector<BusCallback> busCallbacks_;
+};
+
+void attachPinCallbackApi(lua_State *lua, int tableIndex, IDSIMPIN *pin, LuaEventDispatcher *dispatcher);
+void attachBusCallbackApi(lua_State *lua, int tableIndex, IBUSPIN *bus, LuaEventDispatcher *dispatcher);
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/device/pin.cc
+++ b/model/cpp/luabind/device/pin.cc
@@ -1,6 +1,7 @@
 #include <log/log.hpp>
 #include "model.hpp"
 #include "pin_timing.hpp"
+#include "lua_event_dispatcher.hpp"
 #include "lua.hpp"
 #include "lua_stack_guard.hpp"
 #include "luabind/device/pin.hpp"
@@ -277,10 +278,16 @@ static const luaL_Reg VsmPinMethodsLib[] = {{"set", l_pin_set},
 
 namespace
 {
-void registerPinLibrary(lua_State *luaContext, const model_pin &pin)
+void registerPinLibrary(lua_State *luaContext, const model_pin &pin, IDSIMPIN *nativePin = nullptr,
+                        LuaEventDispatcher *dispatcher = nullptr)
 {
     LuaScripting::LuaStackGuard stackGuard(luaContext);
     luaL_newlib(luaContext, VsmPinMethodsLib);
+
+    if (nativePin != nullptr && dispatcher != nullptr)
+    {
+        attachPinCallbackApi(luaContext, -1, nativePin, dispatcher);
+    }
 
     lua_pushinteger(luaContext, pin.number);
     lua_setfield(luaContext, -2, "pinNumber");
@@ -306,6 +313,6 @@ void registerPinLibrary(lua_State *luaContext, const char *name, int number)
 void VirtualDevice::registerPin(const model_pin &pin)
 {
     LOG_DEBUG("Registering pin {}-{}\n", pin.name, pin.number);
-    registerPinLibrary(luactx_, pin);
+    registerPinLibrary(luactx_, pin, getPin(const_cast<CHAR *>(pin.name.c_str())), eventDispatcher_.get());
 }
 } // namespace DeviceSimulator

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -7,6 +7,7 @@
 #include "model_script_path.hpp"
 #include "lua_callback.hpp"
 #include "luabind/device/pin_timing.hpp"
+#include "luabind/device/lua_event_dispatcher.hpp"
 #include "lua_script_executor.hpp"
 #include "vsm_lua_api.hpp"
 #include <windows.h>
@@ -58,6 +59,7 @@ VirtualDevice::VirtualDevice()
     {
         throw std::runtime_error("Failed to create a new Lua state");
     }
+    eventDispatcher_ = std::make_unique<LuaEventDispatcher>(luactx_, this);
 
     LuaScripting::LuaStackGuard stackGuard(luactx_);
     luaL_openlibs(luactx_);
@@ -86,6 +88,7 @@ VirtualDevice::~VirtualDevice()
 {
     LOG_DEBUG("Destroying the device\n");
     VirtualContextManager::getInstance().unregisterDevice(*this);
+    eventDispatcher_.reset();
     lua_close(luactx_);
 }
 
@@ -256,6 +259,7 @@ void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
 
     auto &vinstance = VirtualContextManager::getInstance();
     vinstance.setCurrentDevice(deviceID_);
+    eventDispatcher_->dispatch(time, mode);
 
     lua_getglobal(luactx_, "device_simulate");
     if (!lua_isfunction(luactx_, -1))

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -2,11 +2,14 @@
 #include <vsm.hpp>
 #include <lua.hpp>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace DeviceSimulator
 {
+class LuaEventDispatcher;
+
 struct model_pin
 {
     std::string name;
@@ -49,6 +52,11 @@ class VirtualDevice : public IDSIMMODEL
         return dsim_;
     }
 
+    LuaEventDispatcher &getEventDispatcher() const
+    {
+        return *eventDispatcher_;
+    }
+
   private:
     void registerPin(const model_pin &pin);
     bool registerBuses();
@@ -61,6 +69,7 @@ class VirtualDevice : public IDSIMMODEL
     std::string deviceGUID_;
     bool simulationCallbackEnabled_ = true;
     bool modelReady_ = false;
+    std::unique_ptr<LuaEventDispatcher> eventDispatcher_;
 };
 
 class VirtualContextManager

--- a/model/tests/object_callback_test.cc
+++ b/model/tests/object_callback_test.cc
@@ -1,0 +1,360 @@
+#include "luabind/device/lua_event_dispatcher.hpp"
+
+#include <iostream>
+
+namespace
+{
+class LuaState
+{
+  public:
+    LuaState() : lua_(luaL_newstate())
+    {
+    }
+
+    ~LuaState()
+    {
+        if (lua_ != nullptr)
+        {
+            lua_close(lua_);
+        }
+    }
+
+    lua_State *get() const
+    {
+        return lua_;
+    }
+
+  private:
+    lua_State *lua_;
+};
+
+class FakeModel final : public IDSIMMODEL
+{
+  public:
+    INT isdigital(CHAR *) override
+    {
+        return 1;
+    }
+
+    void setup(IINSTANCE *, IDSIMCKT *) override
+    {
+    }
+
+    void runctrl(RUNMODES) override
+    {
+    }
+
+    void actuate(REALTIME, ACTIVESTATE) override
+    {
+    }
+
+    BOOL indicate(REALTIME, ACTIVEDATA *) override
+    {
+        return TRUE;
+    }
+
+    void simulate(ABSTIME, DSIMMODES) override
+    {
+    }
+
+    void callback(ABSTIME, EVENTID) override
+    {
+    }
+};
+
+class FakePin final : public IDSIMPIN
+{
+  public:
+    STATE state = SLO;
+    IDSIMMODEL *handlerModel = nullptr;
+    PINHANDLERFN handler = nullptr;
+
+    BOOL invert() override
+    {
+        return FALSE;
+    }
+
+    STATE istate() override
+    {
+        return state;
+    }
+
+    BOOL issteady() override
+    {
+        return TRUE;
+    }
+
+    INT activity() override
+    {
+        return 0;
+    }
+
+    BOOL isactive() override
+    {
+        return FALSE;
+    }
+
+    BOOL isinactive() override
+    {
+        return TRUE;
+    }
+
+    BOOL isposedge() override
+    {
+        return FALSE;
+    }
+
+    BOOL isnegedge() override
+    {
+        return FALSE;
+    }
+
+    BOOL isedge() override
+    {
+        return FALSE;
+    }
+
+    EVENT *setstate(ABSTIME, RELTIME, RELTIME, RELTIME, STATE) override
+    {
+        return nullptr;
+    }
+
+    EVENT *setstate(ABSTIME, RELTIME, STATE) override
+    {
+        return nullptr;
+    }
+
+    void setstate(STATE newState) override
+    {
+        state = newState;
+    }
+
+    void sethandler(IDSIMMODEL *model, PINHANDLERFN function) override
+    {
+        handlerModel = model;
+        handler = function;
+    }
+
+    DSIMNODE getnode() override
+    {
+        return nullptr;
+    }
+
+    STATE getstate() override
+    {
+        return state;
+    }
+
+    void settiming(RELTIME, RELTIME, RELTIME) override
+    {
+    }
+
+    void setstates(STATE, STATE, STATE) override
+    {
+    }
+
+    EVENT *drivebool(ABSTIME, BOOL) override
+    {
+        return nullptr;
+    }
+
+    EVENT *drivestate(ABSTIME, STATE) override
+    {
+        return nullptr;
+    }
+
+    EVENT *drivetristate(ABSTIME) override
+    {
+        return nullptr;
+    }
+};
+
+class FakeBus final : public IBUSPIN
+{
+  public:
+    DWORD value = 0;
+    IDSIMMODEL *handlerModel = nullptr;
+    PINHANDLERFN handler = nullptr;
+
+    void settiming(RELTIME, RELTIME, RELTIME) override
+    {
+    }
+
+    void setstates(STATE, STATE, STATE) override
+    {
+    }
+
+    void sethandler(IDSIMMODEL *model, PINHANDLERFN function) override
+    {
+        handlerModel = model;
+        handler = function;
+    }
+
+    void drivebusvalue(ABSTIME, DWORD newValue) override
+    {
+        value = newValue;
+    }
+
+    void drivetristate(ABSTIME) override
+    {
+    }
+
+    void drivebitstate(ABSTIME, UINT, STATE) override
+    {
+    }
+
+    DWORD getbusvalue() override
+    {
+        return value;
+    }
+
+    DWORD getbusdrive() override
+    {
+        return value;
+    }
+
+    STATE getbitstate(UINT) override
+    {
+        return UNDEFINED;
+    }
+};
+
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+
+bool checkCounters(lua_State *lua, int pinChanges, int pinMatches, int busChanges, int busMatches, int failures,
+                   int lateCalls)
+{
+    lua_getglobal(lua, "check_counters");
+    lua_pushinteger(lua, pinChanges);
+    lua_pushinteger(lua, pinMatches);
+    lua_pushinteger(lua, busChanges);
+    lua_pushinteger(lua, busMatches);
+    lua_pushinteger(lua, failures);
+    lua_pushinteger(lua, lateCalls);
+    if (lua_pcall(lua, 6, 0, 0) == LUA_OK)
+    {
+        return true;
+    }
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+} // namespace
+
+int main()
+{
+    LuaState luaState;
+    auto *lua = luaState.get();
+    if (lua == nullptr)
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+
+    FakeModel model;
+    FakePin pin;
+    FakeBus bus;
+    {
+        DeviceSimulator::LuaEventDispatcher dispatcher{lua, &model};
+
+        lua_newtable(lua);
+        DeviceSimulator::attachPinCallbackApi(lua, -1, &pin, &dispatcher);
+        lua_setglobal(lua, "P");
+
+        lua_newtable(lua);
+        lua_pushinteger(lua, 4);
+        lua_setfield(lua, -2, "width");
+        DeviceSimulator::attachBusCallbackApi(lua, -1, &bus, &dispatcher);
+        lua_setglobal(lua, "B");
+
+        const char *registrations = R"(
+            pin_changes, pin_matches = 0, 0
+            bus_changes, bus_matches = 0, 0
+            failures, late_calls = 0, 0
+            late_registered = false
+
+            P:onchange(function(time, mode, state)
+                assert(type(time) == "number" and type(mode) == "number" and type(state) == "number")
+                pin_changes = pin_changes + 1
+                if not late_registered then
+                    late_registered = true
+                    P:onchange(function() late_calls = late_calls + 1 end)
+                end
+            end)
+            P:onstate(15, function(_, _, state)
+                assert(state == 15)
+                pin_matches = pin_matches + 1
+            end)
+            P:onchange(function()
+                failures = failures + 1
+                error("expected callback failure")
+            end)
+
+            B:onchange(function(_, _, value)
+                assert(type(value) == "number")
+                bus_changes = bus_changes + 1
+            end)
+            B:onvalue(5, function(_, _, value)
+                assert(value == 5)
+                bus_matches = bus_matches + 1
+            end)
+
+            assert(not pcall(function() P:onstate(0x100000000, function() end) end))
+            assert(not pcall(function() B:onvalue(16, function() end) end))
+
+            function check_counters(pc, pm, bc, bm, f, late)
+                assert(pin_changes == pc and pin_matches == pm)
+                assert(bus_changes == bc and bus_matches == bm)
+                assert(failures == f and late_calls == late)
+            end
+        )";
+        if (!run(lua, registrations) || pin.handlerModel != &model || pin.handler != &IDSIMMODEL::simulate ||
+            bus.handlerModel != &model || bus.handler != &IDSIMMODEL::simulate)
+        {
+            std::cerr << "Object callbacks did not register native handlers\n";
+            return 1;
+        }
+
+        const int stackTop = lua_gettop(lua);
+        pin.state = SHI;
+        bus.value = 5;
+        dispatcher.dispatch(100, DSIMNORMAL);
+        if (lua_gettop(lua) != stackTop || !checkCounters(lua, 1, 1, 1, 1, 1, 0))
+        {
+            return 1;
+        }
+
+        dispatcher.dispatch(101, DSIMNORMAL);
+        if (!checkCounters(lua, 1, 1, 1, 1, 1, 0))
+        {
+            return 1;
+        }
+
+        pin.state = SLO;
+        bus.value = 6;
+        dispatcher.dispatch(102, DSIMSETTLE);
+        if (!checkCounters(lua, 2, 1, 2, 1, 1, 1))
+        {
+            return 1;
+        }
+
+        pin.state = SHI;
+        bus.value = 5;
+        dispatcher.dispatch(103, DSIMNORMAL);
+        if (!checkCounters(lua, 3, 2, 3, 2, 1, 2))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `pin:onchange` and `pin:onstate` Lua registrations backed by `IDSIMPIN::sethandler`
- add `bus:onchange` and `bus:onvalue` registrations backed by `IBUSPIN::sethandler`
- dispatch only registered objects after an actual state/value transition
- forward simulation time, mode, and the new state/value to Lua
- preserve the Lua stack, allow callbacks to register more callbacks safely, and disable only a callback that throws
- release all Lua registry references before the model's Lua state closes
- document the object callback contract and add native pin/bus regression coverage

## Dependencies
- This is a stacked PR whose base is native-bus PR #71.
- Callback registration is intended from `device_init`; the corrected post-object initialization order is supplied independently by lifecycle PR #69.

## Validation
- `cmake -S . -B .build/object-callbacks -A Win32 -DBUILD_TESTS=ON`
- `cmake --build .build/object-callbacks --config Debug --target object_callback_test native_bus_test VSM_DLL`
- `ctest --test-dir .build/object-callbacks -C Debug --output-on-failure -R object_callback|native_bus`
- `tools/format.ps1 -Check`

The build still reports the known legacy MSVC flag warnings fixed separately by #61 and the local vcpkg `pwsh.exe` warning.

Closes #18