### PR TITLE
Initialize UART output before the first frame

### DIFF
--- a/docs/V0.7-LUA-COMPATIBILITY.md
+++ b/docs/V0.7-LUA-COMPATIBILITY.md
@@ -49,7 +49,8 @@ Status meanings:
 | `device_init`, `device_simulate`, `timer_callback` | **Planned** | Stack safety and dispatch are tracked by #48 and #49. |
 | Pin/bus event objects | **Planned** | Tracked by #18. |
 | Precompiled device scripts | **Planned** | The CMake bytecode path is retained, but the old C module loader was incompatible. |
-| `custom`, `fifo`, and `uart` bundled modules | **Deliberately removed** | Their generated legacy C modules were not carried into the C++ rewrite. Models should provide ordinary Lua modules explicitly. |
+| `uart` module | **Supported** | Shipped as ordinary Lua source under `model/lua/modules`; uses the v0.7 callback API and initializes the line idle-high. |
+| `custom` and `fifo` bundled modules | **Deliberately removed** | Their generated legacy C modules were not carried into the C++ rewrite. Models should provide ordinary Lua modules explicitly. |
 
 ## Migration rules
 

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -210,4 +210,15 @@ if(BUILD_TESTS)
   endif()
 
   add_test(NAME object_callback COMMAND object_callback_test)
+
+  add_executable(uart_module_test tests/uart_module_test.cc)
+  target_link_libraries(uart_module_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(uart_module_test PRIVATE /EHsc)
+  endif()
+
+  add_test(
+    NAME uart_module
+    COMMAND uart_module_test "${CMAKE_CURRENT_SOURCE_DIR}/lua/modules/uart.lua"
+  )
 endif()

--- a/model/lua/modules/README.md
+++ b/model/lua/modules/README.md
@@ -1,0 +1,28 @@
+# Lua modules
+
+The source modules in this directory can be copied beneath `%LUAVSM%\modules`.
+Load the UART module from a model script and construct it after pin objects
+exist:
+
+```lua
+local script_root = assert(os.getenv("LUAVSM"))
+local Uart = dofile(script_root .. "/modules/uart.lua")
+local uart
+
+function device_init()
+    uart = Uart.new(TX, {baud = 9600, event_id = 42})
+    uart:send_string("Hello")
+    uart:send(systime())
+end
+
+function timer_callback(time, event_id)
+    if event_id == uart.event_id then
+        uart:send(time)
+    end
+end
+```
+
+`Uart.new` drives the transmit pin high immediately, before any start bit. The
+module sends 8-N-1 frames, least-significant bit first, and uses the v0.7
+`set_callback` API for bit timing. `bit_time` may be supplied directly for
+nonstandard clocks; otherwise it is rounded from `SEC / baud`.

--- a/model/lua/modules/uart.lua
+++ b/model/lua/modules/uart.lua
@@ -1,0 +1,96 @@
+local Uart = {}
+Uart.__index = Uart
+
+Uart.DEFAULT_EVENT_ID = 3955961
+Uart.DEFAULT_BAUD = 9600
+
+local function check_integer(value, name)
+    assert(math.type(value) == "integer", name .. " must be an integer")
+    return value
+end
+
+function Uart.new(pin, options)
+    assert(type(pin) == "table" and type(pin.set) == "function", "UART requires a pin object")
+    options = options or {}
+
+    local baud = options.baud or Uart.DEFAULT_BAUD
+    assert(type(baud) == "number" and baud > 0, "UART baud must be positive")
+
+    local self = setmetatable({}, Uart)
+    self.tx = pin
+    self.event_id = check_integer(options.event_id or Uart.DEFAULT_EVENT_ID, "UART event ID")
+    self.bit_time = check_integer(options.bit_time or math.floor(SEC / baud + 0.5), "UART bit time")
+    assert(self.bit_time > 0, "UART bit time must be positive")
+    self.queue = {}
+    self.head = 1
+    self.tail = 0
+    self.data = nil
+    self.bit = 0
+
+    -- A UART line must be idle-high before the first start bit. Leaving the
+    -- newly created pin floating/low is what corrupted the legacy first frame.
+    self.tx:set(1)
+    return self
+end
+
+setmetatable(Uart, {
+    __call = function(_, ...)
+        return Uart.new(...)
+    end
+})
+
+function Uart:send_byte(value)
+    value = check_integer(value, "UART byte")
+    assert(value >= 0 and value <= 0xff, "UART byte must be from 0 to 255")
+    self.tail = self.tail + 1
+    self.queue[self.tail] = value
+end
+
+function Uart:send_string(value)
+    assert(type(value) == "string", "UART payload must be a string")
+    for index = 1, #value do
+        self:send_byte(string.byte(value, index))
+    end
+    return #value
+end
+
+function Uart:busy()
+    return self.data ~= nil or self.head <= self.tail
+end
+
+function Uart:send(time)
+    time = check_integer(time, "UART time")
+
+    if self.data == nil then
+        if self.head > self.tail then
+            return false
+        end
+        self.data = self.queue[self.head]
+        self.queue[self.head] = nil
+        self.head = self.head + 1
+        self.bit = 0
+    end
+
+    if self.bit == 0 then
+        self.tx:set(0)
+    elseif self.bit <= 8 then
+        self.tx:set((self.data >> (self.bit - 1)) & 1)
+    else
+        self.tx:set(1)
+    end
+
+    if self.bit == 9 then
+        self.data = nil
+        self.bit = 0
+        if self.head > self.tail then
+            return true
+        end
+    else
+        self.bit = self.bit + 1
+    end
+
+    set_callback(time + self.bit_time, self.event_id)
+    return true
+end
+
+return Uart

--- a/model/tests/uart_module_test.cc
+++ b/model/tests/uart_module_test.cc
@@ -1,0 +1,157 @@
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+#include <lua.hpp>
+
+namespace
+{
+struct ScheduledCallback
+{
+    lua_Integer time;
+    lua_Integer eventId;
+};
+
+struct Harness
+{
+    std::vector<int> pinLevels;
+    std::vector<ScheduledCallback> callbacks;
+};
+
+Harness *harness(lua_State *lua)
+{
+    return static_cast<Harness *>(lua_touserdata(lua, lua_upvalueindex(1)));
+}
+
+int setPin(lua_State *lua)
+{
+    const auto value = luaL_checkinteger(lua, 2);
+    if (value != 0 && value != 1)
+    {
+        return luaL_argerror(lua, 2, "UART test pin accepts only zero or one");
+    }
+    harness(lua)->pinLevels.push_back(static_cast<int>(value));
+    return 0;
+}
+
+int scheduleCallback(lua_State *lua)
+{
+    harness(lua)->callbacks.push_back({luaL_checkinteger(lua, 1), luaL_checkinteger(lua, 2)});
+    return 0;
+}
+
+bool callSend(lua_State *lua, lua_Integer time)
+{
+    lua_getglobal(lua, "uart");
+    lua_getfield(lua, -1, "send");
+    lua_pushvalue(lua, -2);
+    lua_pushinteger(lua, time);
+    if (lua_pcall(lua, 2, 1, 0) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_pop(lua, 2);
+        return false;
+    }
+    const bool sent = lua_toboolean(lua, -1) != 0;
+    lua_pop(lua, 2);
+    return sent;
+}
+} // namespace
+
+int main(int argumentCount, char **arguments)
+{
+    if (argumentCount != 2)
+    {
+        std::cerr << "Expected the UART Lua module path\n";
+        return 1;
+    }
+
+    auto *lua = luaL_newstate();
+    if (lua == nullptr)
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+
+    Harness test;
+    lua_pushinteger(lua, 1000000000000LL);
+    lua_setglobal(lua, "SEC");
+    lua_pushlightuserdata(lua, &test);
+    lua_pushcclosure(lua, scheduleCallback, 1);
+    lua_setglobal(lua, "set_callback");
+
+    lua_newtable(lua);
+    lua_pushlightuserdata(lua, &test);
+    lua_pushcclosure(lua, setPin, 1);
+    lua_setfield(lua, -2, "set");
+    lua_setglobal(lua, "TX");
+
+    if (luaL_dofile(lua, arguments[1]) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+    lua_setglobal(lua, "Uart");
+
+    const char *configure = R"(
+        uart = Uart.new(TX, {bit_time = 100, event_id = 77})
+        assert(uart:send_string(string.char(0x55, 0xa3)) == 2)
+        assert(not pcall(function() uart:send_byte(256) end))
+    )";
+    if (luaL_dostring(lua, configure) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+    if (!callSend(lua, 1000))
+    {
+        std::cerr << "UART did not start a queued frame\n";
+        lua_close(lua);
+        return 1;
+    }
+
+    for (std::size_t index = 0; index < test.callbacks.size(); ++index)
+    {
+        if (!callSend(lua, test.callbacks[index].time))
+        {
+            std::cerr << "UART stopped before the queued frames completed\n";
+            lua_close(lua);
+            return 1;
+        }
+    }
+
+    const std::vector<int> expectedLevels = {
+        1,                            // idle before the first packet
+        0, 1, 0, 1, 0, 1, 0, 1, 0, 1, // start, 0x55 LSB first, stop
+        0, 1, 1, 0, 0, 0, 1, 0, 1, 1  // start, 0xa3 LSB first, stop
+    };
+    if (test.pinLevels != expectedLevels || test.callbacks.size() != 19)
+    {
+        std::cerr << "UART frame levels or callback count did not match 8-N-1 output\n";
+        lua_close(lua);
+        return 1;
+    }
+
+    for (std::size_t index = 0; index < test.callbacks.size(); ++index)
+    {
+        const auto expectedTime = 1100 + static_cast<lua_Integer>(index) * 100;
+        if (test.callbacks[index].time != expectedTime || test.callbacks[index].eventId != 77)
+        {
+            std::cerr << "UART callback timing or event ID changed\n";
+            lua_close(lua);
+            return 1;
+        }
+    }
+
+    if (luaL_dostring(lua, "assert(not uart:busy())") != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+
+    lua_close(lua);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- initialize the UART TX output to idle-high before the first start bit
- provide a Lua 5.4-compatible 8-N-1 transmitter without the removed `fifo` or `bit32` dependencies
- support queued bytes and strings, configurable baud/bit time, and callback event IDs
- document the module and its compatibility status
- verify the exact line levels and callback timing for consecutive frames

## Dependencies

This PR is stacked on #72 for the v0.7 `SEC`, `systime`, and `set_callback` compatibility API. Runtime initialization through `device_init` also depends on #69.

## Validation

- `cmake -S . -B .build/uart -A Win32 -DBUILD_TESTS=ON`
- `cmake --build .build/uart --config Debug --target uart_module_test vsm_lua_api_test`
- both CTest cases passed
- full `VSM_DLL` Debug build passed after preparing the existing legacy `luac` compatibility path
- `./tools/format.ps1 -Check` passed

The build still reports the repository's existing configuration-independent MSVC flag warnings; #61 addresses those separately.

Closes #7