### PR TITLE
Add a Lua bridge for the VDM target API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The executable Lua compatibility surface and v0.7 migration notes are listed in
 The v0.7 architecture and generated C++ reference are described in
 [`docs/DEVELOPER-GUIDE.md`](docs/DEVELOPER-GUIDE.md).
 
+CPU-like models can implement the SDK's Virtual Debug Monitor protocol through
+the [`Lua VDM target bridge`](docs/VDM-LUA-API.md).
+
 Prebuilt DLL and symbols or installer are in [Release](https://github.com/Pugnator/openvsm/releases) section
 
 The v0.7 native model is written in C++20 and currently builds with 32-bit MSVC.

--- a/docs/V0.7-LUA-COMPATIBILITY.md
+++ b/docs/V0.7-LUA-COMPATIBILITY.md
@@ -48,6 +48,7 @@ Status meanings:
 | Native bus objects | **Planned** | Implemented by #54; legacy table-wide `set_bus`/`get_bus` are not restored. |
 | `device_init`, `device_simulate`, `timer_callback` | **Planned** | Stack safety and dispatch are tracked by #48 and #49. |
 | Pin/bus event objects | **Planned** | Tracked by #18. |
+| Virtual Debug Monitor | **Supported** | CPU-like models can implement `device_vdm_command` and optional loader/disassembler callbacks; see `VDM-LUA-API.md`. |
 | Precompiled device scripts | **Planned** | The CMake bytecode path is retained, but the old C module loader was incompatible. |
 | `uart` module | **Supported** | Shipped as ordinary Lua source under `model/lua/modules`; uses the v0.7 callback API and initializes the line idle-high. |
 | `custom` and `fifo` bundled modules | **Deliberately removed** | Their generated legacy C modules were not carried into the C++ rewrite. Models should provide ordinary Lua modules explicitly. |

--- a/docs/VDM-LUA-API.md
+++ b/docs/VDM-LUA-API.md
@@ -1,0 +1,60 @@
+# Lua VDM target bridge
+
+The Proteus SDK already supplies the Virtual Debug Monitor protocol in
+`vdm.hpp`; reverse engineering another model DLL is not required. A CPU-like
+OpenVSM model can opt in by defining `device_vdm_command`. OpenVSM then registers
+the model through `IINSTANCE::setvdmhlr` and forwards host VDM commands to Lua.
+
+## Command callback
+
+```lua
+function device_vdm_command(command, memspace, address, length, payload)
+    -- Return a VDM status and, for reads, an optional binary string.
+    return ERR_VDM_OK, response
+end
+```
+
+The five arguments are the fields of the SDK `VDM_COMMAND` plus the request
+payload. `payload` is a binary-safe Lua string for `VDM_WRITEDATA` and
+`VDM_WRITEREGS`; it is empty for other commands. The optional response must not
+exceed the requested `length`. OpenVSM copies it to the SDK buffer and reports
+its actual length. A Lua error becomes `ERR_VDM_SIMFAILED`, an invalid result
+becomes `ERR_VDM_FAILED`, and an oversized result becomes
+`ERR_VDM_BADDATALEN`.
+
+Lua 5.4 `string.pack` and `string.unpack` are suitable for register blocks and
+the fixed-layout SDK structures. For example, a four-byte program counter can
+be returned with `string.pack("<I4", pc)`.
+
+The bridge registers `VDM_API_VERSION`, the `VDM*_CLASS` target classes, all
+`VDM_*` command constants, and the host-facing `ERR_VDM_*` result constants.
+Target-specific memory-space numbers and register layouts remain the model's
+responsibility; the SDK headers `vdm11.hpp`, `vdm51.hpp`, and `vdmpic.hpp`
+define the standard layouts.
+
+## Loader and disassembler callbacks
+
+CPU models may also define:
+
+```lua
+function device_vdm_load(format, segment, address, payload)
+    -- Consume a binary chunk supplied by the Proteus loader.
+end
+
+function device_vdm_disassemble(address, length)
+    -- Update model-specific disassembly state if required.
+end
+```
+
+Both callbacks are optional and isolated from the C++ stack. The SDK
+`getvardata` service is deliberately reported as unsupported for now because it
+requires stable, model-owned memory and type descriptors; returning temporary
+Lua storage would create dangling host pointers.
+
+## External client
+
+The other half of the SDK is `vdmapi.dll`. A third-party debugger opens a
+handle with `vdm_open`, initializes it with `vdm_init`, and then uses the
+documented play, pause, memory, register, breakpoint, and PC functions. The
+default SDK transport port is 8000. Distribution of Labcenter binaries and
+headers remains subject to the Proteus SDK licence and is outside OpenVSM.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -34,6 +34,7 @@ set(DLL_SRC
   ${SRCDIR}/luabind/device/pin_timing.cc
   ${SRCDIR}/luabind/lua_facade.cc
   ${SRCDIR}/luabind/lua_script_executor.cc
+  ${SRCDIR}/luabind/vdm_lua_api.cc
   ${SRCDIR}/luabind/vsm_lua_api.cc
 )
 
@@ -221,4 +222,19 @@ if(BUILD_TESTS)
     NAME uart_module
     COMMAND uart_module_test "${CMAKE_CURRENT_SOURCE_DIR}/lua/modules/uart.lua"
   )
+
+  add_executable(vdm_lua_api_test
+    tests/vdm_lua_api_test.cc
+    ${SRCDIR}/luabind/vdm_lua_api.cc
+  )
+  target_include_directories(vdm_lua_api_test PRIVATE
+    ${SRCDIR}
+    ${CMAKE_SOURCE_DIR}/externals/sdk
+  )
+  target_link_libraries(vdm_lua_api_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(vdm_lua_api_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME vdm_lua_api COMMAND vdm_lua_api_test)
 endif()

--- a/model/cpp/luabind/vdm_lua_api.cc
+++ b/model/cpp/luabind/vdm_lua_api.cc
@@ -1,0 +1,210 @@
+#include "vdm_lua_api.hpp"
+
+#include <cstring>
+
+namespace
+{
+class StackRestore
+{
+  public:
+    explicit StackRestore(lua_State *lua) : lua_(lua), top_(lua_gettop(lua))
+    {
+    }
+
+    ~StackRestore()
+    {
+        lua_settop(lua_, top_);
+    }
+
+  private:
+    lua_State *lua_;
+    int top_;
+};
+
+void setInteger(lua_State *lua, const char *name, lua_Integer value)
+{
+    lua_pushinteger(lua, value);
+    lua_setglobal(lua, name);
+}
+
+bool commandHasInput(BYTE command)
+{
+    return command == VDM_WRITEDATA || command == VDM_WRITEREGS;
+}
+
+bool pushOptionalCallback(lua_State *lua, const char *name)
+{
+    lua_getglobal(lua, name);
+    if (lua_isfunction(lua, -1))
+    {
+        return true;
+    }
+
+    lua_pop(lua, 1);
+    return false;
+}
+} // namespace
+
+namespace DeviceSimulator
+{
+void registerVdmLuaApi(lua_State *lua)
+{
+    if (!lua)
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    setInteger(lua, "VDM_API_VERSION", VDM_API_VERSION);
+    setInteger(lua, "VDM51_CLASS", VDM51_CLASS);
+    setInteger(lua, "VDM11_CLASS", VDM11_CLASS);
+    setInteger(lua, "VDMPIC16_CLASS", VDMPIC16_CLASS);
+    setInteger(lua, "VDMAVR_CLASS", VDMAVR_CLASS);
+    setInteger(lua, "VDMPIC18_CLASS", VDMPIC18_CLASS);
+    setInteger(lua, "VDMARM7_CLASS", VDMARM7_CLASS);
+
+    setInteger(lua, "VDM_INIT", VDM_INIT);
+    setInteger(lua, "VDM_TERM", VDM_TERM);
+    setInteger(lua, "VDM_PLAY", VDM_PLAY);
+    setInteger(lua, "VDM_STEP", VDM_STEP);
+    setInteger(lua, "VDM_PAUSE", VDM_PAUSE);
+    setInteger(lua, "VDM_WRITEDATA", VDM_WRITEDATA);
+    setInteger(lua, "VDM_READDATA", VDM_READDATA);
+    setInteger(lua, "VDM_READREGS", VDM_READREGS);
+    setInteger(lua, "VDM_WRITEREGS", VDM_WRITEREGS);
+    setInteger(lua, "VDM_SETBP", VDM_SETBP);
+    setInteger(lua, "VDM_CLRBP", VDM_CLRBP);
+    setInteger(lua, "VDM_SETPC", VDM_SETPC);
+    setInteger(lua, "VDM_GETPC", VDM_GETPC);
+    setInteger(lua, "VDM_RESET", VDM_RESET);
+    setInteger(lua, "VDM_GETTID", VDM_GETTID);
+
+    setInteger(lua, "ERR_VDM_FAILED", ERR_VDM_FAILED);
+    setInteger(lua, "ERR_VDM_OK", ERR_VDM_OK);
+    setInteger(lua, "ERR_VDM_TIMEOUT", ERR_VDM_TIMEOUT);
+    setInteger(lua, "ERR_VDM_BADCOMMAND", ERR_VDM_BADCOMMAND);
+    setInteger(lua, "ERR_VDM_BADADDRESS", ERR_VDM_BADADDRESS);
+    setInteger(lua, "ERR_VDM_BADDATALEN", ERR_VDM_BADDATALEN);
+    setInteger(lua, "ERR_VDM_SIMFAILED", ERR_VDM_SIMFAILED);
+    setInteger(lua, "ERR_VDM_NOTARGET", ERR_VDM_NOTARGET);
+}
+
+bool hasLuaVdmHandler(lua_State *lua)
+{
+    if (!lua)
+    {
+        return false;
+    }
+
+    StackRestore restore(lua);
+    lua_getglobal(lua, "device_vdm_command");
+    return lua_isfunction(lua, -1);
+}
+
+LRESULT dispatchLuaVdmCommand(lua_State *lua, VDM_COMMAND *command, BYTE *data)
+{
+    if (!lua || !command)
+    {
+        return ERR_VDM_FAILED;
+    }
+
+    StackRestore restore(lua);
+    lua_getglobal(lua, "device_vdm_command");
+    if (!lua_isfunction(lua, -1))
+    {
+        return ERR_VDM_NOTARGET;
+    }
+
+    lua_pushinteger(lua, command->command);
+    lua_pushinteger(lua, command->memspace);
+    lua_pushinteger(lua, command->address);
+    lua_pushinteger(lua, command->datalength);
+
+    if (commandHasInput(command->command) && command->datalength != 0)
+    {
+        if (!data)
+        {
+            return ERR_VDM_BADDATALEN;
+        }
+        lua_pushlstring(lua, reinterpret_cast<const char *>(data), command->datalength);
+    }
+    else
+    {
+        lua_pushliteral(lua, "");
+    }
+
+    if (lua_pcall(lua, 5, 2, 0) != LUA_OK)
+    {
+        return ERR_VDM_SIMFAILED;
+    }
+
+    int isInteger = 0;
+    const lua_Integer result = lua_tointegerx(lua, -2, &isInteger);
+    if (!isInteger)
+    {
+        return ERR_VDM_FAILED;
+    }
+
+    if (result != ERR_VDM_OK || lua_isnil(lua, -1))
+    {
+        return static_cast<LRESULT>(result);
+    }
+
+    size_t outputSize = 0;
+    const char *output = lua_tolstring(lua, -1, &outputSize);
+    if (!output)
+    {
+        return ERR_VDM_FAILED;
+    }
+    if (outputSize > command->datalength || (outputSize != 0 && !data))
+    {
+        return ERR_VDM_BADDATALEN;
+    }
+
+    if (outputSize != 0)
+    {
+        std::memcpy(data, output, outputSize);
+    }
+    command->datalength = static_cast<DWORD>(outputSize);
+    return ERR_VDM_OK;
+}
+
+void dispatchLuaVdmLoad(lua_State *lua, INT format, INT segment, ADDRESS address, const BYTE *data, INT numbytes)
+{
+    if (!lua || numbytes < 0 || (numbytes != 0 && !data))
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    if (!pushOptionalCallback(lua, "device_vdm_load"))
+    {
+        return;
+    }
+
+    lua_pushinteger(lua, format);
+    lua_pushinteger(lua, segment);
+    lua_pushinteger(lua, address);
+    const char *payload = data ? reinterpret_cast<const char *>(data) : "";
+    lua_pushlstring(lua, payload, static_cast<size_t>(numbytes));
+    lua_pcall(lua, 4, 0, 0);
+}
+
+void dispatchLuaVdmDisassemble(lua_State *lua, ADDRESS address, INT numbytes)
+{
+    if (!lua || numbytes < 0)
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    if (!pushOptionalCallback(lua, "device_vdm_disassemble"))
+    {
+        return;
+    }
+
+    lua_pushinteger(lua, address);
+    lua_pushinteger(lua, numbytes);
+    lua_pcall(lua, 2, 0, 0);
+}
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/vdm_lua_api.hpp
+++ b/model/cpp/luabind/vdm_lua_api.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <lua.hpp>
+#include <vsm.hpp>
+#include <vdm.hpp>
+
+namespace DeviceSimulator
+{
+void registerVdmLuaApi(lua_State *lua);
+bool hasLuaVdmHandler(lua_State *lua);
+LRESULT dispatchLuaVdmCommand(lua_State *lua, VDM_COMMAND *command, BYTE *data);
+void dispatchLuaVdmLoad(lua_State *lua, INT format, INT segment, ADDRESS address, const BYTE *data, INT numbytes);
+void dispatchLuaVdmDisassemble(lua_State *lua, ADDRESS address, INT numbytes);
+} // namespace DeviceSimulator

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -9,6 +9,7 @@
 #include "luabind/device/pin_timing.hpp"
 #include "luabind/device/lua_event_dispatcher.hpp"
 #include "lua_script_executor.hpp"
+#include "vdm_lua_api.hpp"
 #include "vsm_lua_api.hpp"
 #include <windows.h>
 #include <combaseapi.h>
@@ -129,6 +130,7 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     const auto scriptPathText = scriptPath.path.string();
     LOG_DEBUG("Loading model script {}\n", scriptPathText);
     registerVsmLuaApi(luactx_, instance_, dsim_, this);
+    registerVdmLuaApi(luactx_);
     auto scripter = std::make_unique<LuaScripting::ScriptExecutor>(luactx_);
     bool result = scripter->loadScriptFromTextFile(scriptPathText.c_str());
     if (!result)
@@ -139,6 +141,11 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     }
     scripter->execute();
     lua_settop(luactx_, stackGuard.top());
+
+    if (hasLuaVdmHandler(luactx_) && !instance_->setvdmhlr(this))
+    {
+        LOG_DEBUG("Proteus rejected the Lua VDM handler\n");
+    }
 
     lua_getglobal(luactx_, "device_pins");
 
@@ -295,6 +302,28 @@ void VirtualDevice::callback(ABSTIME time, EVENTID eventid)
     {
         LOG_DEBUG("Timer callback failed with \"{}\"\n", callback.error);
     }
+}
+
+LRESULT VirtualDevice::vdmhlr(VDM_COMMAND *command, BYTE *data)
+{
+    return dispatchLuaVdmCommand(luactx_, command, data);
+}
+
+void VirtualDevice::loaddata(INT format, INT segment, ADDRESS address, BYTE *data, INT numbytes)
+{
+    dispatchLuaVdmLoad(luactx_, format, segment, address, data, numbytes);
+}
+
+void VirtualDevice::disassemble(ADDRESS address, INT numbytes)
+{
+    dispatchLuaVdmDisassemble(luactx_, address, numbytes);
+}
+
+BOOL VirtualDevice::getvardata(VARITEM *item, VARDATA *data)
+{
+    (void)item;
+    (void)data;
+    return FALSE;
 }
 
 const lua_State *VirtualContextManager::getDeviceLuaContext(const std::string &id)

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -25,7 +25,7 @@ struct model_pin
  * Proteus owns the host interface pointers passed to setup(). VirtualDevice
  * owns luactx_ and closes it when the concrete model is destroyed.
  */
-class VirtualDevice : public IDSIMMODEL
+class VirtualDevice : public IDSIMMODEL, public ICPU
 {
   public:
     /** Allocate and initialize the model's Lua state. */
@@ -47,6 +47,11 @@ class VirtualDevice : public IDSIMMODEL
     void simulate(ABSTIME time, DSIMMODES mode) override;
     /** Deliver a scheduled host event to the Lua model. */
     void callback(ABSTIME time, EVENTID eventid) override;
+
+    LRESULT vdmhlr(VDM_COMMAND *command, BYTE *data) override;
+    void loaddata(INT format, INT segment, ADDRESS address, BYTE *data, INT numbytes) override;
+    void disassemble(ADDRESS address, INT numbytes) override;
+    BOOL getvardata(VARITEM *item, VARDATA *data) override;
 
     /** Return the Lua state owned by this model. The pointer is non-owning. */
     lua_State *getLuaContext() const

--- a/model/tests/vdm_lua_api_test.cc
+++ b/model/tests/vdm_lua_api_test.cc
@@ -1,0 +1,147 @@
+#include "luabind/vdm_lua_api.hpp"
+
+#include <array>
+#include <iostream>
+#include <string>
+
+namespace
+{
+bool expect(bool condition, const char *message)
+{
+    if (!condition)
+    {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+
+std::string globalString(lua_State *lua, const char *name)
+{
+    lua_getglobal(lua, name);
+    size_t size = 0;
+    const char *value = lua_tolstring(lua, -1, &size);
+    std::string result = value ? std::string(value, size) : std::string();
+    lua_pop(lua, 1);
+    return result;
+}
+
+lua_Integer globalInteger(lua_State *lua, const char *name)
+{
+    lua_getglobal(lua, name);
+    const lua_Integer value = lua_tointeger(lua, -1);
+    lua_pop(lua, 1);
+    return value;
+}
+} // namespace
+
+int main()
+{
+    lua_State *lua = luaL_newstate();
+    if (!expect(lua != nullptr, "Lua state creation failed"))
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+
+    const int initialTop = lua_gettop(lua);
+    DeviceSimulator::registerVdmLuaApi(lua);
+    bool ok = expect(lua_gettop(lua) == initialTop, "constant registration changed the Lua stack") &&
+              expect(globalInteger(lua, "VDM_READDATA") == VDM_READDATA, "VDM_READDATA was not registered") &&
+              expect(globalInteger(lua, "ERR_VDM_OK") == ERR_VDM_OK, "ERR_VDM_OK was not registered") &&
+              expect(!DeviceSimulator::hasLuaVdmHandler(lua), "missing handler was reported as present");
+
+    ok = run(lua, R"(
+        function device_vdm_command(command, memspace, address, length, payload)
+            last_command = command
+            last_memspace = memspace
+            last_address = address
+            last_length = length
+            last_payload = payload
+            if command == VDM_READDATA then
+                return ERR_VDM_OK, string.char(0x11, 0x00, 0xff)
+            elseif command == VDM_WRITEDATA then
+                return ERR_VDM_OK
+            elseif command == VDM_STEP then
+                error("step failed")
+            elseif command == VDM_GETPC then
+                return ERR_VDM_OK, string.rep("x", length + 1)
+            end
+            return ERR_VDM_BADCOMMAND
+        end
+
+        function device_vdm_load(format, segment, address, payload)
+            load_format = format
+            load_segment = segment
+            load_address = address
+            load_payload = payload
+        end
+
+        function device_vdm_disassemble(address, length)
+            disassemble_address = address
+            disassemble_length = length
+        end
+    )") &&
+         ok;
+
+    ok = expect(DeviceSimulator::hasLuaVdmHandler(lua), "VDM handler was not detected") && ok;
+
+    std::array<BYTE, 3> readBuffer = {};
+    VDM_COMMAND readCommand = {VDM_READDATA, 2, 0x1234, static_cast<DWORD>(readBuffer.size())};
+    ok = expect(DeviceSimulator::dispatchLuaVdmCommand(lua, &readCommand, readBuffer.data()) == ERR_VDM_OK,
+                "read command failed") &&
+         expect(readBuffer == std::array<BYTE, 3>{0x11, 0x00, 0xff}, "read payload was not copied") &&
+         expect(readCommand.datalength == 3, "read payload length was not returned") &&
+         expect(globalInteger(lua, "last_memspace") == 2, "memory space was not forwarded") &&
+         expect(globalInteger(lua, "last_address") == 0x1234, "address was not forwarded") && ok;
+
+    std::array<BYTE, 4> writeBuffer = {0xde, 0xad, 0x00, 0xbe};
+    VDM_COMMAND writeCommand = {VDM_WRITEDATA, 4, 0x88, static_cast<DWORD>(writeBuffer.size())};
+    ok = expect(DeviceSimulator::dispatchLuaVdmCommand(lua, &writeCommand, writeBuffer.data()) == ERR_VDM_OK,
+                "write command failed") &&
+         expect(globalString(lua, "last_payload") == std::string("\xde\xad\x00\xbe", 4),
+                "binary write payload was not forwarded") &&
+         ok;
+
+    VDM_COMMAND stepCommand = {VDM_STEP, 0, 0, 0};
+    ok = expect(DeviceSimulator::dispatchLuaVdmCommand(lua, &stepCommand, nullptr) == ERR_VDM_SIMFAILED,
+                "Lua command error was not isolated") &&
+         expect(lua_gettop(lua) == initialTop, "VDM command changed the Lua stack") && ok;
+
+    std::array<BYTE, 4> pcBuffer = {};
+    VDM_COMMAND pcCommand = {VDM_GETPC, 0, 0, static_cast<DWORD>(pcBuffer.size())};
+    ok = expect(DeviceSimulator::dispatchLuaVdmCommand(lua, &pcCommand, pcBuffer.data()) == ERR_VDM_BADDATALEN,
+                "oversized VDM response was accepted") &&
+         ok;
+
+    std::array<BYTE, 3> loadData = {1, 0, 3};
+    DeviceSimulator::dispatchLuaVdmLoad(lua, 7, 8, 0x200, loadData.data(), static_cast<INT>(loadData.size()));
+    DeviceSimulator::dispatchLuaVdmDisassemble(lua, 0x300, 16);
+    ok = expect(globalString(lua, "load_payload") == std::string("\x01\x00\x03", 3),
+                "loader payload was not forwarded") &&
+         expect(globalInteger(lua, "load_format") == 7, "loader format was not forwarded") &&
+         expect(globalInteger(lua, "disassemble_address") == 0x300, "disassembly address was not forwarded") &&
+         expect(globalInteger(lua, "disassemble_length") == 16, "disassembly length was not forwarded") &&
+         expect(lua_gettop(lua) == initialTop, "optional VDM callbacks changed the Lua stack") && ok;
+
+    lua_close(lua);
+
+    lua = luaL_newstate();
+    ok = expect(DeviceSimulator::dispatchLuaVdmCommand(lua, &stepCommand, nullptr) == ERR_VDM_NOTARGET,
+                "missing command handler did not return ERR_VDM_NOTARGET") &&
+         ok;
+    lua_close(lua);
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- implement the SDK `ICPU` surface on each Lua-backed `VirtualDevice`
- register a model with `IINSTANCE::setvdmhlr` only when it defines `device_vdm_command`
- forward VDM command fields and binary-safe write/register payloads to Lua
- copy bounded Lua response payloads back to the SDK buffer and map malformed/error paths to documented VDM results
- expose VDM command, result, API-version, and target-class constants before the model script loads
- forward optional loader and disassembler callbacks
- document both the target-side Lua contract and the external `vdmapi.dll` client flow

`getvardata` deliberately returns `FALSE`: that SDK service requires stable model-owned memory/type descriptors, and lending temporary Lua storage would leave Proteus with dangling pointers.

## Dependency

This PR is stacked on #72 so it extends the defined v0.7 compatibility surface.

## Validation

- configured Visual Studio 2022 Win32 with `BUILD_TESTS=ON`
- `vdm_lua_api_test` passed binary reads/writes (including NUL bytes), constants, command fields, size rejection, optional callbacks, missing handlers, Lua failures, and stack balance
- existing `vsm_lua_api_test` passed
- full Debug `VSM_DLL` build passed
- `./tools/format.ps1 -Check` passed

The full DLL build still shows the existing MSVC flag warnings handled separately by #61. A live Proteus/VDM client test is not available in this environment, so this remains a draft for host verification.

Closes #17