### PR TITLE
Add Lua graphics and animation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ the [`Lua VDM target bridge`](docs/VDM-LUA-API.md).
 Any model can expose bounded state to external tools with the
 [`VDM third-party control profile`](docs/THIRD-PARTY-CONTROL.md).
 
+Active displays and animated components can use the
+[`Lua graphics and animation API`](docs/GRAPHICS-LUA-API.md).
+
 Prebuilt DLL and symbols or installer are in [Release](https://github.com/Pugnator/openvsm/releases) section
 
 The v0.7 native model is written in C++20 and currently builds with 32-bit MSVC.

--- a/docs/GRAPHICS-LUA-API.md
+++ b/docs/GRAPHICS-LUA-API.md
@@ -1,0 +1,51 @@
+# Lua graphics and animation API
+
+OpenVSM can export a Proteus active model and a digital model from the same C++
+object and Lua state. Set the component's `LUA` property as for an ordinary v0.7
+model; relative paths are resolved below `LUAVSM`. Proteus calls the active
+model for drawing and user input while its digital side continues to receive
+pin simulation events.
+
+An active model may define any of these callbacks:
+
+```lua
+function device_graphics_init()
+end
+
+function device_graphics_plot(state)
+end
+
+function device_graphics_animate(element, data_type, value)
+end
+
+function device_graphics_actuate(key, x, y, flags)
+    return false -- true when the input was handled
+end
+```
+
+`device_graphics_init` runs once after both the script and Proteus component
+surface are available. `device_graphics_animate` receives primitive values
+directly. Wire information is `{ voltage=..., current=... }`; SPICE and digital
+sample blocks contain `num_timepoints`, `num_pins`, `timepoints`, and a flat
+`nodes` or `states` array. User-pointer animation data is deliberately `nil`.
+
+The global `graphics` table provides:
+
+- drawing: `draw_line`, `draw_box`, `draw_circle`, `draw_symbol`, `draw_state`,
+  and format-safe `draw_text`;
+- vector style: `set_draw_scale`, `set_pen_width`, `set_pen_colour`, and
+  `set_brush_colour`;
+- text style: `set_text_font`, `set_text_size`, `set_bold`, `set_italic`,
+  `set_underline`, and `set_text_colour`;
+- component services: `get_symbol_area`, `get_marker`, `repaint`, and
+  `set_timestep`;
+- Proteus colour, text-justification, actuation-flag, and active-data constants.
+
+Coordinates and sizes use the active component's drawing units. Timesteps use
+seconds, matching `ICOMPONENT::settimestep`. `draw_text` always passes model
+text as data rather than as a native format string, so percent characters are
+safe.
+
+The pointer-valued cache, style, and popup handles are not exposed to portable
+Lua models. They require an ownership/lifetime design before they can be added
+safely.

--- a/examples/graphics/README.md
+++ b/examples/graphics/README.md
@@ -1,0 +1,11 @@
+# Active display example
+
+`display.lua` is a minimal active-model script. Configure an active Proteus
+component to load `openvsm.dll`, set its `LUA` property to `graphics/display.lua`,
+and set `LUAVSM` to the repository's `examples` directory. The model draws a
+two-digit display and increments it when the active area receives a left click.
+
+The example intentionally declares no digital pins. A real screen model can add
+ordinary `device_pins` or `device_buses` and update its drawing state from the
+same Lua state. Proteus project/library metadata is version-specific and is not
+included; use the component editor for the installed Proteus version.

--- a/examples/graphics/display.lua
+++ b/examples/graphics/display.lua
@@ -1,0 +1,39 @@
+device_pins = {}
+
+local value = 0
+
+function device_init()
+end
+
+function device_simulate()
+end
+
+function device_graphics_init()
+    graphics.set_draw_scale(96)
+    graphics.set_pen_width(1)
+    graphics.set_text_size(14)
+    graphics.set_text_colour(graphics.BRIGHTGREEN)
+end
+
+function device_graphics_plot(state)
+    graphics.set_pen_colour(graphics.BRIGHTGREEN)
+    graphics.set_brush_colour(graphics.BLACK)
+    graphics.draw_box(0, 0, 160, 60)
+    graphics.draw_text(80, 30, 0, graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, string.format("%02X", value))
+end
+
+function device_graphics_animate(element, data_type, new_value)
+    if data_type == graphics.ADT_INTEGER then
+        value = new_value & 0xff
+        graphics.repaint(false)
+    end
+end
+
+function device_graphics_actuate(key, x, y, flags)
+    if (flags & graphics.ACF_LEFT) ~= 0 then
+        value = (value + 1) & 0xff
+        graphics.repaint(false)
+        return true
+    end
+    return false
+end

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRCDIR cpp)
 
 set(DLL_SRC
   ${SRCDIR}/dllmain.cc
+  ${SRCDIR}/active_model.cc
   ${SRCDIR}/model.cc
   ${SRCDIR}/luabind/device/bus.cc
   ${SRCDIR}/model_script_path.cc
@@ -32,6 +33,7 @@ set(DLL_SRC
   ${SRCDIR}/luabind/device/pin.cc
   ${SRCDIR}/luabind/lua_callback.cc
   ${SRCDIR}/luabind/device/pin_timing.cc
+  ${SRCDIR}/luabind/graphics_lua_api.cc
   ${SRCDIR}/luabind/lua_facade.cc
   ${SRCDIR}/luabind/lua_script_executor.cc
   ${SRCDIR}/luabind/vdm_lua_api.cc
@@ -255,4 +257,19 @@ if(BUILD_TESTS)
     NAME vdm_control_module
     COMMAND vdm_control_module_test "${CMAKE_CURRENT_SOURCE_DIR}/lua/modules/vdm_control.lua"
   )
+
+  add_executable(graphics_lua_api_test
+    tests/graphics_lua_api_test.cc
+    ${SRCDIR}/luabind/graphics_lua_api.cc
+  )
+  target_include_directories(graphics_lua_api_test PRIVATE
+    ${SRCDIR}
+    ${CMAKE_SOURCE_DIR}/externals/sdk
+  )
+  target_link_libraries(graphics_lua_api_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(graphics_lua_api_test PRIVATE /EHsc)
+  endif()
+
+  add_test(NAME graphics_lua_api COMMAND graphics_lua_api_test)
 endif()

--- a/model/cpp/active_model.cc
+++ b/model/cpp/active_model.cc
@@ -1,0 +1,64 @@
+#include "active_model.hpp"
+
+#include "luabind/graphics_lua_api.hpp"
+
+namespace DeviceSimulator
+{
+void LuaActiveModel::initialize(ICOMPONENT *component)
+{
+    component_ = component;
+    if (component_)
+    {
+        registerGraphicsLuaApi(getLuaContext(), component_);
+        ensureGraphicsInitialized();
+    }
+}
+
+ISPICEMODEL *LuaActiveModel::getspicemodel(CHAR *primitive)
+{
+    (void)primitive;
+    return nullptr;
+}
+
+IDSIMMODEL *LuaActiveModel::getdsimmodel(CHAR *primitive)
+{
+    (void)primitive;
+    return this;
+}
+
+void LuaActiveModel::plot(ACTIVESTATE state)
+{
+    ensureGraphicsInitialized();
+    dispatchLuaGraphicsPlot(getLuaContext(), state);
+}
+
+void LuaActiveModel::animate(INT element, ACTIVEDATA *newstate)
+{
+    ensureGraphicsInitialized();
+    dispatchLuaGraphicsAnimate(getLuaContext(), element, newstate);
+}
+
+BOOL LuaActiveModel::actuate(WORD key, INT x, INT y, DWORD flags)
+{
+    ensureGraphicsInitialized();
+    return dispatchLuaGraphicsActuate(getLuaContext(), key, x, y, flags) ? TRUE : FALSE;
+}
+
+void LuaActiveModel::setup(IINSTANCE *instance, IDSIMCKT *dsim)
+{
+    if (component_)
+    {
+        registerGraphicsLuaApi(getLuaContext(), component_);
+    }
+    VirtualDevice::setup(instance, dsim);
+    ensureGraphicsInitialized();
+}
+
+void LuaActiveModel::ensureGraphicsInitialized()
+{
+    if (!graphicsInitialized_)
+    {
+        graphicsInitialized_ = dispatchLuaGraphicsInit(getLuaContext());
+    }
+}
+} // namespace DeviceSimulator

--- a/model/cpp/active_model.hpp
+++ b/model/cpp/active_model.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "model.hpp"
+
+namespace DeviceSimulator
+{
+class LuaActiveModel final : public VirtualDevice, public IACTIVEMODEL
+{
+  public:
+    void initialize(ICOMPONENT *component) override;
+    ISPICEMODEL *getspicemodel(CHAR *primitive) override;
+    IDSIMMODEL *getdsimmodel(CHAR *primitive) override;
+    void plot(ACTIVESTATE state) override;
+    void animate(INT element, ACTIVEDATA *newstate) override;
+    BOOL actuate(WORD key, INT x, INT y, DWORD flags) override;
+
+    void setup(IINSTANCE *instance, IDSIMCKT *dsim) override;
+
+  private:
+    void ensureGraphicsInitialized();
+
+    ICOMPONENT *component_ = nullptr;
+    bool graphicsInitialized_ = false;
+};
+} // namespace DeviceSimulator

--- a/model/cpp/dllmain.cc
+++ b/model/cpp/dllmain.cc
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <vsm.hpp>
 #include <log/log.hpp>
+#include "active_model.hpp"
 #include "model.hpp"
 
 namespace
@@ -15,6 +16,21 @@ bool vsmRegister(ILICENCESERVER *ils)
 
 extern "C"
 {
+    IACTIVEMODEL __declspec(dllexport) * createactivemodel(char *device, ILICENCESERVER *ils)
+    {
+        (void)device;
+        if (!ils || !vsmRegister(ils))
+        {
+            return nullptr;
+        }
+        return new DeviceSimulator::LuaActiveModel;
+    }
+
+    void __declspec(dllexport) deleteactivemodel(IACTIVEMODEL *model)
+    {
+        delete static_cast<DeviceSimulator::LuaActiveModel *>(model);
+    }
+
     IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
     {
         (void)device;

--- a/model/cpp/luabind/graphics_lua_api.cc
+++ b/model/cpp/luabind/graphics_lua_api.cc
@@ -1,0 +1,462 @@
+#include "graphics_lua_api.hpp"
+
+#include <cstdint>
+
+namespace
+{
+class StackRestore
+{
+  public:
+    explicit StackRestore(lua_State *lua) : lua_(lua), top_(lua_gettop(lua))
+    {
+    }
+
+    ~StackRestore()
+    {
+        lua_settop(lua_, top_);
+    }
+
+  private:
+    lua_State *lua_;
+    int top_;
+};
+
+ICOMPONENT *component(lua_State *lua)
+{
+    return static_cast<ICOMPONENT *>(lua_touserdata(lua, lua_upvalueindex(1)));
+}
+
+int setDrawScale(lua_State *lua)
+{
+    component(lua)->setdrawscale(static_cast<INT>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int setPenWidth(lua_State *lua)
+{
+    component(lua)->setpenwidth(static_cast<INT>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int setPenColour(lua_State *lua)
+{
+    component(lua)->setpencolour(static_cast<COLOUR>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int setBrushColour(lua_State *lua)
+{
+    component(lua)->setbrushcolour(static_cast<COLOUR>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int setTextFont(lua_State *lua)
+{
+    const char *font = luaL_checkstring(lua, 1);
+    component(lua)->settextfont(const_cast<char *>(font));
+    return 0;
+}
+
+int setTextSize(lua_State *lua)
+{
+    component(lua)->settextsize(static_cast<INT>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int setBold(lua_State *lua)
+{
+    component(lua)->setbold(lua_toboolean(lua, 1) ? TRUE : FALSE);
+    return 0;
+}
+
+int setItalic(lua_State *lua)
+{
+    component(lua)->setitalic(lua_toboolean(lua, 1) ? TRUE : FALSE);
+    return 0;
+}
+
+int setUnderline(lua_State *lua)
+{
+    component(lua)->setunderline(lua_toboolean(lua, 1) ? TRUE : FALSE);
+    return 0;
+}
+
+int setTextColour(lua_State *lua)
+{
+    component(lua)->settextcolour(static_cast<COLOUR>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int drawLine(lua_State *lua)
+{
+    component(lua)->drawline(static_cast<INT>(luaL_checkinteger(lua, 1)), static_cast<INT>(luaL_checkinteger(lua, 2)),
+                             static_cast<INT>(luaL_checkinteger(lua, 3)), static_cast<INT>(luaL_checkinteger(lua, 4)));
+    return 0;
+}
+
+int drawBox(lua_State *lua)
+{
+    component(lua)->drawbox(static_cast<INT>(luaL_checkinteger(lua, 1)), static_cast<INT>(luaL_checkinteger(lua, 2)),
+                            static_cast<INT>(luaL_checkinteger(lua, 3)), static_cast<INT>(luaL_checkinteger(lua, 4)));
+    return 0;
+}
+
+int drawCircle(lua_State *lua)
+{
+    component(lua)->drawcircle(static_cast<INT>(luaL_checkinteger(lua, 1)), static_cast<INT>(luaL_checkinteger(lua, 2)),
+                               static_cast<INT>(luaL_checkinteger(lua, 3)));
+    return 0;
+}
+
+int drawSymbol(lua_State *lua)
+{
+    if (lua_gettop(lua) == 1)
+    {
+        component(lua)->drawsymbol(static_cast<INT>(luaL_checkinteger(lua, 1)));
+    }
+    else
+    {
+        component(lua)->drawsymbol(
+            static_cast<INT>(luaL_checkinteger(lua, 1)), static_cast<INT>(luaL_checkinteger(lua, 2)),
+            static_cast<INT>(luaL_checkinteger(lua, 3)), static_cast<INT>(luaL_checkinteger(lua, 4)),
+            static_cast<INT>(luaL_checkinteger(lua, 5)));
+    }
+    return 0;
+}
+
+int drawState(lua_State *lua)
+{
+    component(lua)->drawstate(static_cast<ACTIVESTATE>(luaL_checkinteger(lua, 1)));
+    return 0;
+}
+
+int drawText(lua_State *lua)
+{
+    const INT x = static_cast<INT>(luaL_checkinteger(lua, 1));
+    const INT y = static_cast<INT>(luaL_checkinteger(lua, 2));
+    const INT rotation = static_cast<INT>(luaL_checkinteger(lua, 3));
+    const INT justification = static_cast<INT>(luaL_checkinteger(lua, 4));
+    const char *text = luaL_checkstring(lua, 5);
+    component(lua)->drawtext(x, y, rotation, justification, const_cast<char *>("%s"), text);
+    return 0;
+}
+
+int getSymbolArea(lua_State *lua)
+{
+    BOX area = {};
+    if (!component(lua)->getsymbolarea(static_cast<INT>(luaL_checkinteger(lua, 1)), &area))
+    {
+        return 0;
+    }
+
+    lua_pushinteger(lua, area.x1);
+    lua_pushinteger(lua, area.y1);
+    lua_pushinteger(lua, area.x2);
+    lua_pushinteger(lua, area.y2);
+    return 4;
+}
+
+int getMarker(lua_State *lua)
+{
+    const char *name = luaL_checkstring(lua, 1);
+    POINT position = {};
+    INT rotation = 0;
+    INT mirror = 0;
+    if (!component(lua)->getmarker(const_cast<char *>(name), &position, &rotation, &mirror))
+    {
+        return 0;
+    }
+
+    lua_pushinteger(lua, position.x);
+    lua_pushinteger(lua, position.y);
+    lua_pushinteger(lua, rotation);
+    lua_pushinteger(lua, mirror);
+    return 4;
+}
+
+int repaint(lua_State *lua)
+{
+    const bool erase = lua_gettop(lua) == 0 || lua_toboolean(lua, 1);
+    component(lua)->repaint(erase ? TRUE : FALSE);
+    return 0;
+}
+
+int setTimestep(lua_State *lua)
+{
+    component(lua)->settimestep(luaL_checknumber(lua, 1));
+    return 0;
+}
+
+void setFunction(lua_State *lua, ICOMPONENT *target, const char *name, lua_CFunction function)
+{
+    lua_pushlightuserdata(lua, target);
+    lua_pushcclosure(lua, function, 1);
+    lua_setfield(lua, -2, name);
+}
+
+void setInteger(lua_State *lua, const char *name, lua_Integer value)
+{
+    lua_pushinteger(lua, value);
+    lua_setfield(lua, -2, name);
+}
+
+bool pushCallback(lua_State *lua, const char *name)
+{
+    lua_getglobal(lua, name);
+    if (lua_isfunction(lua, -1))
+    {
+        return true;
+    }
+    lua_pop(lua, 1);
+    return false;
+}
+
+void setTableInteger(lua_State *lua, const char *name, lua_Integer value)
+{
+    lua_pushinteger(lua, value);
+    lua_setfield(lua, -2, name);
+}
+
+void pushActiveData(lua_State *lua, const ACTIVEDATA *data)
+{
+    if (!data)
+    {
+        lua_pushnil(lua);
+        return;
+    }
+
+    switch (data->type)
+    {
+    case ADT_REAL:
+    case ADT_PINVOLTAGE:
+        lua_pushnumber(lua, data->realval);
+        return;
+    case ADT_BOOLEAN:
+        lua_pushboolean(lua, data->intval != 0);
+        return;
+    case ADT_INTEGER:
+        lua_pushinteger(lua, data->intval);
+        return;
+    case ADT_STATE:
+    case ADT_PINSTATE:
+        lua_pushinteger(lua, data->stateval);
+        return;
+    case ADT_WIREINFO:
+        lua_createtable(lua, 0, 2);
+        lua_pushnumber(lua, data->wireinfo[0]);
+        lua_setfield(lua, -2, "voltage");
+        lua_pushnumber(lua, data->wireinfo[1]);
+        lua_setfield(lua, -2, "current");
+        return;
+    case ADT_SPICEDATA:
+    {
+        const auto &source = data->spicedata;
+        const uint64_t sampleCount = static_cast<uint64_t>(source.numtimepoints) * source.numpins;
+        if ((source.numtimepoints != 0 && !source.timepoints) || (sampleCount != 0 && !source.nodedata) ||
+            source.numtimepoints > 1024 * 1024 || sampleCount > 1024 * 1024)
+        {
+            lua_pushnil(lua);
+            return;
+        }
+        lua_createtable(lua, 0, 4);
+        setTableInteger(lua, "num_timepoints", source.numtimepoints);
+        setTableInteger(lua, "num_pins", source.numpins);
+        lua_createtable(lua, static_cast<int>(source.numtimepoints), 0);
+        for (DWORD i = 0; i < source.numtimepoints; ++i)
+        {
+            lua_pushnumber(lua, source.timepoints[i]);
+            lua_rawseti(lua, -2, i + 1);
+        }
+        lua_setfield(lua, -2, "timepoints");
+        lua_createtable(lua, static_cast<int>(sampleCount), 0);
+        for (uint64_t i = 0; i < sampleCount; ++i)
+        {
+            lua_pushnumber(lua, source.nodedata[i]);
+            lua_rawseti(lua, -2, static_cast<lua_Integer>(i + 1));
+        }
+        lua_setfield(lua, -2, "nodes");
+        return;
+    }
+    case ADT_DSIMDATA:
+    {
+        const auto &source = data->dsimdata;
+        const uint64_t sampleCount = static_cast<uint64_t>(source.numtimepoints) * source.numpins;
+        if ((source.numtimepoints != 0 && !source.timepoints) || (sampleCount != 0 && !source.nodedata) ||
+            source.numtimepoints > 1024 * 1024 || sampleCount > 1024 * 1024)
+        {
+            lua_pushnil(lua);
+            return;
+        }
+        lua_createtable(lua, 0, 4);
+        setTableInteger(lua, "num_timepoints", source.numtimepoints);
+        setTableInteger(lua, "num_pins", source.numpins);
+        lua_createtable(lua, static_cast<int>(source.numtimepoints), 0);
+        for (DWORD i = 0; i < source.numtimepoints; ++i)
+        {
+            lua_pushinteger(lua, source.timepoints[i]);
+            lua_rawseti(lua, -2, i + 1);
+        }
+        lua_setfield(lua, -2, "timepoints");
+        lua_createtable(lua, static_cast<int>(sampleCount), 0);
+        for (uint64_t i = 0; i < sampleCount; ++i)
+        {
+            lua_pushinteger(lua, source.nodedata[i]);
+            lua_rawseti(lua, -2, static_cast<lua_Integer>(i + 1));
+        }
+        lua_setfield(lua, -2, "states");
+        return;
+    }
+    case ADT_VOID:
+    case ADT_USER:
+    default:
+        lua_pushnil(lua);
+        return;
+    }
+}
+} // namespace
+
+namespace DeviceSimulator
+{
+void registerGraphicsLuaApi(lua_State *lua, ICOMPONENT *target)
+{
+    if (!lua || !target)
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    lua_createtable(lua, 0, 64);
+
+    setFunction(lua, target, "set_draw_scale", setDrawScale);
+    setFunction(lua, target, "set_pen_width", setPenWidth);
+    setFunction(lua, target, "set_pen_colour", setPenColour);
+    setFunction(lua, target, "set_brush_colour", setBrushColour);
+    setFunction(lua, target, "set_text_font", setTextFont);
+    setFunction(lua, target, "set_text_size", setTextSize);
+    setFunction(lua, target, "set_bold", setBold);
+    setFunction(lua, target, "set_italic", setItalic);
+    setFunction(lua, target, "set_underline", setUnderline);
+    setFunction(lua, target, "set_text_colour", setTextColour);
+    setFunction(lua, target, "draw_line", drawLine);
+    setFunction(lua, target, "draw_box", drawBox);
+    setFunction(lua, target, "draw_circle", drawCircle);
+    setFunction(lua, target, "draw_symbol", drawSymbol);
+    setFunction(lua, target, "draw_state", drawState);
+    setFunction(lua, target, "draw_text", drawText);
+    setFunction(lua, target, "get_symbol_area", getSymbolArea);
+    setFunction(lua, target, "get_marker", getMarker);
+    setFunction(lua, target, "repaint", repaint);
+    setFunction(lua, target, "set_timestep", setTimestep);
+
+    setInteger(lua, "BLACK", BLACK);
+    setInteger(lua, "WHITE", WHITE);
+    setInteger(lua, "GREY", GREY);
+    setInteger(lua, "RED", RED);
+    setInteger(lua, "GREEN", GREEN);
+    setInteger(lua, "BLUE", BLUE);
+    setInteger(lua, "CYAN", CYAN);
+    setInteger(lua, "MAGENTA", MAGENTA);
+    setInteger(lua, "YELLOW", YELLOW);
+    setInteger(lua, "BRIGHTWHITE", BRIGHTWHITE);
+    setInteger(lua, "BRIGHTRED", BRIGHTRED);
+    setInteger(lua, "BRIGHTGREEN", BRIGHTGREEN);
+    setInteger(lua, "BRIGHTBLUE", BRIGHTBLUE);
+    setInteger(lua, "TXJ_LEFT", TXJ_LEFT);
+    setInteger(lua, "TXJ_RIGHT", TXJ_RIGHT);
+    setInteger(lua, "TXJ_CENTRE", TXJ_CENTRE);
+    setInteger(lua, "TXJ_TOP", TXJ_TOP);
+    setInteger(lua, "TXJ_MIDDLE", TXJ_MIDDLE);
+    setInteger(lua, "TXJ_BOTTOM", TXJ_BOTTOM);
+    setInteger(lua, "ACF_LEFT", ACF_LEFT);
+    setInteger(lua, "ACF_RIGHT", ACF_RIGHT);
+    setInteger(lua, "ACF_MIDDLE", ACF_MIDDLE);
+    setInteger(lua, "ACF_INC", ACF_INC);
+    setInteger(lua, "ACF_DEC", ACF_DEC);
+    setInteger(lua, "ACF_TOGGLE", ACF_TOGGLE);
+    setInteger(lua, "ADT_VOID", ADT_VOID);
+    setInteger(lua, "ADT_REAL", ADT_REAL);
+    setInteger(lua, "ADT_BOOLEAN", ADT_BOOLEAN);
+    setInteger(lua, "ADT_INTEGER", ADT_INTEGER);
+    setInteger(lua, "ADT_STATE", ADT_STATE);
+    setInteger(lua, "ADT_PINVOLTAGE", ADT_PINVOLTAGE);
+    setInteger(lua, "ADT_PINSTATE", ADT_PINSTATE);
+    setInteger(lua, "ADT_WIREINFO", ADT_WIREINFO);
+    setInteger(lua, "ADT_SPICEDATA", ADT_SPICEDATA);
+    setInteger(lua, "ADT_DSIMDATA", ADT_DSIMDATA);
+
+    lua_setglobal(lua, "graphics");
+}
+
+bool dispatchLuaGraphicsInit(lua_State *lua)
+{
+    if (!lua)
+    {
+        return false;
+    }
+
+    StackRestore restore(lua);
+    if (!pushCallback(lua, "device_graphics_init"))
+    {
+        return false;
+    }
+    lua_pcall(lua, 0, 0, 0);
+    return true;
+}
+
+void dispatchLuaGraphicsPlot(lua_State *lua, ACTIVESTATE state)
+{
+    if (!lua)
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    if (!pushCallback(lua, "device_graphics_plot"))
+    {
+        return;
+    }
+    lua_pushinteger(lua, state);
+    lua_pcall(lua, 1, 0, 0);
+}
+
+void dispatchLuaGraphicsAnimate(lua_State *lua, INT element, const ACTIVEDATA *data)
+{
+    if (!lua)
+    {
+        return;
+    }
+
+    StackRestore restore(lua);
+    if (!pushCallback(lua, "device_graphics_animate"))
+    {
+        return;
+    }
+    lua_pushinteger(lua, element);
+    lua_pushinteger(lua, data ? data->type : ADT_VOID);
+    pushActiveData(lua, data);
+    lua_pcall(lua, 3, 0, 0);
+}
+
+bool dispatchLuaGraphicsActuate(lua_State *lua, WORD key, INT x, INT y, DWORD flags)
+{
+    if (!lua)
+    {
+        return false;
+    }
+
+    StackRestore restore(lua);
+    if (!pushCallback(lua, "device_graphics_actuate"))
+    {
+        return false;
+    }
+    lua_pushinteger(lua, key);
+    lua_pushinteger(lua, x);
+    lua_pushinteger(lua, y);
+    lua_pushinteger(lua, flags);
+    if (lua_pcall(lua, 4, 1, 0) != LUA_OK)
+    {
+        return false;
+    }
+    return lua_toboolean(lua, -1) != 0;
+}
+} // namespace DeviceSimulator

--- a/model/cpp/luabind/graphics_lua_api.hpp
+++ b/model/cpp/luabind/graphics_lua_api.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <lua.hpp>
+#include <vsm.hpp>
+
+namespace DeviceSimulator
+{
+void registerGraphicsLuaApi(lua_State *lua, ICOMPONENT *component);
+bool dispatchLuaGraphicsInit(lua_State *lua);
+void dispatchLuaGraphicsPlot(lua_State *lua, ACTIVESTATE state);
+void dispatchLuaGraphicsAnimate(lua_State *lua, INT element, const ACTIVEDATA *data);
+bool dispatchLuaGraphicsActuate(lua_State *lua, WORD key, INT x, INT y, DWORD flags);
+} // namespace DeviceSimulator

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -1,10 +1,13 @@
 #pragma once
-#include <vsm.hpp>
-#include <lua.hpp>
+
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <vsm.hpp>
+#include <lua.hpp>
 
 namespace DeviceSimulator
 {

--- a/model/tests/graphics_lua_api_test.cc
+++ b/model/tests/graphics_lua_api_test.cc
@@ -1,0 +1,326 @@
+#include "luabind/graphics_lua_api.hpp"
+
+#include <cstdarg>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+namespace
+{
+class FakeComponent final : public ICOMPONENT
+{
+  public:
+    INT drawScale = 0;
+    INT penWidth = 0;
+    COLOUR penColour = 0;
+    COLOUR brushColour = 0;
+    INT line[4] = {};
+    INT box[4] = {};
+    INT circle[3] = {};
+    std::string text;
+    BOOL repaintedWithErase = FALSE;
+    DOUBLE timestep = 0;
+
+    CHAR *getprop(CHAR *) override
+    {
+        return nullptr;
+    }
+    CHAR *getproptext() override
+    {
+        return nullptr;
+    }
+    void addprop(CHAR *, CHAR *, WORD) override
+    {
+    }
+    void delprop(CHAR *) override
+    {
+    }
+    void setproptext(CHAR *) override
+    {
+    }
+    ACTIVESTATE getstate(INT, ACTIVEDATA *) override
+    {
+        return 0;
+    }
+    BOOL setstate(ACTIVESTATE) override
+    {
+        return TRUE;
+    }
+    void setdrawscale(INT value) override
+    {
+        drawScale = value;
+    }
+    HDC begincache(BOX &) override
+    {
+        return nullptr;
+    }
+    HDC begincache(INT) override
+    {
+        return nullptr;
+    }
+    void endcache() override
+    {
+    }
+    HGFXSTYLE creategfxstyle(CHAR *) override
+    {
+        return nullptr;
+    }
+    void selectgfxstyle(HGFXSTYLE) override
+    {
+    }
+    void setpenwidth(INT value) override
+    {
+        penWidth = value;
+    }
+    void setpencolour(COLOUR value) override
+    {
+        penColour = value;
+    }
+    void setbrushcolour(COLOUR value) override
+    {
+        brushColour = value;
+    }
+    void drawline(INT x1, INT y1, INT x2, INT y2) override
+    {
+        line[0] = x1;
+        line[1] = y1;
+        line[2] = x2;
+        line[3] = y2;
+    }
+    void drawbox(INT x1, INT y1, INT x2, INT y2) override
+    {
+        box[0] = x1;
+        box[1] = y1;
+        box[2] = x2;
+        box[3] = y2;
+    }
+    void drawbox(BOX &area) override
+    {
+        drawbox(area.x1, area.y1, area.x2, area.y2);
+    }
+    void drawcircle(INT x, INT y, INT radius) override
+    {
+        circle[0] = x;
+        circle[1] = y;
+        circle[2] = radius;
+    }
+    void drawbezier(POINT *, INT) override
+    {
+    }
+    void drawpolyline(POINT *, INT) override
+    {
+    }
+    void drawpolygon(POINT *, INT) override
+    {
+    }
+    void drawsymbol(INT) override
+    {
+    }
+    void drawsymbol(INT, INT, INT, INT, INT) override
+    {
+    }
+    void drawstate(ACTIVESTATE) override
+    {
+    }
+    BOOL getsymbolarea(INT symbol, BOX *area) override
+    {
+        if (symbol != 9 || !area)
+        {
+            return FALSE;
+        }
+        area->x1 = 1;
+        area->y1 = 2;
+        area->x2 = 30;
+        area->y2 = 40;
+        return TRUE;
+    }
+    BOOL getmarker(CHAR *name, POINT *position, INT *rotation, INT *mirror) override
+    {
+        if (std::strcmp(name, "ORIGIN") != 0)
+        {
+            return FALSE;
+        }
+        position->x = 5;
+        position->y = 6;
+        *rotation = 90;
+        *mirror = MIR_X;
+        return TRUE;
+    }
+    HTEXTSTYLE createtextstyle(CHAR *) override
+    {
+        return nullptr;
+    }
+    void selecttextstyle(HTEXTSTYLE) override
+    {
+    }
+    void settextfont(CHAR *) override
+    {
+    }
+    void settextsize(INT) override
+    {
+    }
+    void setbold(BOOL) override
+    {
+    }
+    void setitalic(BOOL) override
+    {
+    }
+    void setunderline(BOOL) override
+    {
+    }
+    void settextcolour(COLOUR) override
+    {
+    }
+    void drawtext(INT, INT, INT, INT, CHAR *format, ...) override
+    {
+        va_list arguments;
+        va_start(arguments, format);
+        text = std::strcmp(format, "%s") == 0 ? va_arg(arguments, const char *) : format;
+        va_end(arguments);
+    }
+    IPOPUP *createpopup(CREATEPOPUPSTRUCT *) override
+    {
+        return nullptr;
+    }
+    void deletepopup(POPUPID) override
+    {
+    }
+    void settimestep(DOUBLE value) override
+    {
+        timestep = value;
+    }
+    void error(CHAR *, ...) override
+    {
+    }
+    void repaint(BOOL erase) override
+    {
+        repaintedWithErase = erase;
+    }
+};
+
+bool expect(bool condition, const char *message)
+{
+    if (!condition)
+    {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+
+lua_Integer globalInteger(lua_State *lua, const char *name)
+{
+    lua_getglobal(lua, name);
+    const lua_Integer result = lua_tointeger(lua, -1);
+    lua_pop(lua, 1);
+    return result;
+}
+} // namespace
+
+int main()
+{
+    lua_State *lua = luaL_newstate();
+    if (!expect(lua != nullptr, "Lua state creation failed"))
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+    const int initialTop = lua_gettop(lua);
+
+    FakeComponent component;
+    DeviceSimulator::registerGraphicsLuaApi(lua, &component);
+    bool ok = expect(lua_gettop(lua) == initialTop, "graphics registration changed the Lua stack") && run(lua, R"(
+                  graphics.set_draw_scale(96)
+                  graphics.set_pen_width(3)
+                  graphics.set_pen_colour(0x112233)
+                  graphics.set_brush_colour(0x445566)
+                  graphics.draw_line(1, 2, 3, 4)
+                  graphics.draw_box(5, 6, 7, 8)
+                  graphics.draw_circle(9, 10, 11)
+                  graphics.draw_text(0, 0, 0, graphics.TXJ_LEFT, "100% safe")
+                  marker_x, marker_y, marker_rotation, marker_mirror = graphics.get_marker("ORIGIN")
+                  area_x1, area_y1, area_x2, area_y2 = graphics.get_symbol_area(9)
+                  graphics.repaint()
+                  graphics.set_timestep(0.000001)
+
+                  function device_graphics_init()
+                      init_called = (init_called or 0) + 1
+                  end
+
+                  function device_graphics_plot(state)
+                      plot_state = state
+                  end
+
+                  function device_graphics_animate(element, data_type, value)
+                      animate_element = element
+                      animate_type = data_type
+                      animate_value = value
+                  end
+
+                  function device_graphics_actuate(key, x, y, flags)
+                      actuate_key = key
+                      actuate_flags = flags
+                      return x == 12 and y == 13
+                  end
+              )");
+
+    ok = expect(component.drawScale == 96, "draw scale was not forwarded") &&
+         expect(component.penWidth == 3, "pen width was not forwarded") &&
+         expect(component.penColour == 0x112233, "pen colour was not forwarded") &&
+         expect(component.brushColour == 0x445566, "brush colour was not forwarded") &&
+         expect(component.line[0] == 1 && component.line[3] == 4, "line coordinates were not forwarded") &&
+         expect(component.box[0] == 5 && component.box[3] == 8, "box coordinates were not forwarded") &&
+         expect(component.circle[0] == 9 && component.circle[2] == 11, "circle was not forwarded") &&
+         expect(component.text == "100% safe", "text was treated as a format string") &&
+         expect(component.repaintedWithErase == TRUE, "default repaint did not erase") &&
+         expect(component.timestep == 0.000001, "timestep was not forwarded") &&
+         expect(globalInteger(lua, "marker_rotation") == 90, "marker result was not returned") &&
+         expect(globalInteger(lua, "area_x2") == 30, "symbol area was not returned") && ok;
+
+    ACTIVEDATA data = {};
+    data.type = ADT_INTEGER;
+    data.intval = 42;
+    ok = expect(DeviceSimulator::dispatchLuaGraphicsInit(lua), "graphics init callback was not found") && ok;
+    DeviceSimulator::dispatchLuaGraphicsPlot(lua, 77);
+    DeviceSimulator::dispatchLuaGraphicsAnimate(lua, 3, &data);
+    ok = expect(DeviceSimulator::dispatchLuaGraphicsActuate(lua, 65, 12, 13, ACF_LEFT | ACF_TOGGLE),
+                "actuate callback result was not returned") &&
+         expect(globalInteger(lua, "init_called") == 1, "graphics init was not dispatched") &&
+         expect(globalInteger(lua, "plot_state") == 77, "plot state was not dispatched") &&
+         expect(globalInteger(lua, "animate_element") == 3, "animation element was not dispatched") &&
+         expect(globalInteger(lua, "animate_type") == ADT_INTEGER, "animation type was not dispatched") &&
+         expect(globalInteger(lua, "animate_value") == 42, "animation value was not dispatched") &&
+         expect(globalInteger(lua, "actuate_key") == 65, "actuate key was not dispatched") &&
+         expect(lua_gettop(lua) == initialTop, "graphics callbacks changed the Lua stack") && ok;
+
+    ABSTIME timepoints[] = {100, 200};
+    STATE states[] = {SLO, SHI, FLT, TSTATE};
+    data.type = ADT_DSIMDATA;
+    data.dsimdata = {2, 2, timepoints, states};
+    lua_pushinteger(lua, TSTATE);
+    lua_setglobal(lua, "expected_tstate");
+    DeviceSimulator::dispatchLuaGraphicsAnimate(lua, 4, &data);
+    ok = expect(globalInteger(lua, "animate_element") == 4, "sample-block element was not dispatched") &&
+         expect(globalInteger(lua, "animate_type") == ADT_DSIMDATA, "sample-block type was not dispatched") &&
+         run(lua, "assert(animate_value.num_timepoints == 2); assert(animate_value.timepoints[2] == 200); "
+                  "assert(animate_value.states[4] == expected_tstate)") &&
+         expect(lua_gettop(lua) == initialTop, "sample-block callback changed the Lua stack") && ok;
+
+    ok = run(lua, "function device_graphics_actuate() error('boom') end") && ok;
+    ok = expect(!DeviceSimulator::dispatchLuaGraphicsActuate(lua, 0, 0, 0, 0),
+                "throwing actuate callback was accepted") &&
+         expect(lua_gettop(lua) == initialTop, "throwing callback changed the Lua stack") && ok;
+
+    lua_close(lua);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- export the Proteus `createactivemodel`/`deleteactivemodel` entry points alongside the digital model exports
- use one `LuaActiveModel` object and Lua state for the active and digital sides of a component
- map active initialization, plotting, animation data, and mouse/key actuation to stack-safe Lua callbacks
- expose the SDK's vector drawing, text, marker, symbol-area, repaint, and timestep services through a `graphics` table
- convert primitive, wire, SPICE, and DSIM animation data into bounded Lua values/tables
- pass text through a fixed native `%s` format so model strings cannot become format strings
- add API documentation and a minimal active-display Lua example

Pointer-valued cache/style/popup handles remain intentionally unavailable until they have an explicit ownership and lifetime contract.

## Dependency

This PR is based on #68 (`agent/configure-model-script-path`) so active and digital models share the portable `LUA`/`LUAVSM` script-selection contract.

## Validation

- configured Visual Studio 2022 Win32 with `BUILD_TESTS=ON`
- `graphics_lua_api_test` passed drawing forwarding, marker/symbol results, safe percent text, callback dispatch, actuation results, error isolation, stack balance, and DSIM sample-block conversion
- existing `model_script_path_test` passed
- `luac -p examples/graphics/display.lua` passed
- full Debug `VSM_DLL` build passed
- `dumpbin /exports` confirmed `createactivemodel`, `deleteactivemodel`, `createdsimmodel`, and `deletedsimmodel`
- `./tools/format.ps1 -Check` passed

The existing MSVC option warnings are handled by #61. A live Proteus render/input test is still required because Proteus is not available to the automated test process.

Closes #29