### PR TITLE
Add a generic VDM control profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The v0.7 architecture and generated C++ reference are described in
 CPU-like models can implement the SDK's Virtual Debug Monitor protocol through
 the [`Lua VDM target bridge`](docs/VDM-LUA-API.md).
 
+Any model can expose bounded state to external tools with the
+[`VDM third-party control profile`](docs/THIRD-PARTY-CONTROL.md).
+
 Prebuilt DLL and symbols or installer are in [Release](https://github.com/Pugnator/openvsm/releases) section
 
 The v0.7 native model is written in C++20 and currently builds with 32-bit MSVC.

--- a/docs/THIRD-PARTY-CONTROL.md
+++ b/docs/THIRD-PARTY-CONTROL.md
@@ -1,0 +1,45 @@
+# Third-party model control
+
+OpenVSM uses the Proteus Virtual Debug Monitor as its third-party transport. It
+already supplies connection management, play/pause/step/reset commands, memory
+and register transfers, breakpoints, and program-counter access. Reusing it
+avoids opening an unauthenticated custom socket from every simulated model.
+
+The `vdm_control` Lua module is a generic target profile on top of the Lua VDM
+bridge. A model can expose bounded byte-addressable regions with a few lines:
+
+```lua
+local root = assert(os.getenv("LUAVSM"), "LUAVSM is not set")
+package.path = root .. "/?.lua;" .. package.path
+local Control = require("modules.vdm_control")
+
+control = Control.new({
+    id = "MY-MODEL",
+    regclass = 0,
+    regsize = 8,
+    clock = 1000000
+})
+
+control:register_space(0, 4096)
+control:on(VDM_RESET, function(target)
+    target.pc = 0
+    return ERR_VDM_OK
+end)
+control:install()
+```
+
+`register_space(id, size, initial)` allocates a fixed-size binary region. Reads
+and writes are range checked and preserve embedded NUL bytes. The profile also
+implements target discovery, target information, registers, PC operations, and
+breakpoint bookkeeping. `on(command, callback)` can override or extend any VDM
+command; returning `nil` delegates to the profile's default behavior.
+
+A third-party program uses Labcenter's `vdmapi.dll` client API: open and
+initialize a handle, then call the documented VDM memory/register/control
+functions. The client selects the target using the Proteus VDM configuration;
+the SDK's default transport port is 8000. OpenVSM does not redistribute that DLL
+or its import library, and their use remains subject to the Proteus SDK licence.
+
+The profile runs on the simulator/VDM callback path. Command callbacks should be
+short and deterministic; long-running network or device I/O should be handled
+by the external tool, not while Proteus is waiting for a model response.

--- a/docs/VDM-LUA-API.md
+++ b/docs/VDM-LUA-API.md
@@ -58,3 +58,7 @@ handle with `vdm_open`, initializes it with `vdm_init`, and then uses the
 documented play, pause, memory, register, breakpoint, and PC functions. The
 default SDK transport port is 8000. Distribution of Labcenter binaries and
 headers remains subject to the Proteus SDK licence and is outside OpenVSM.
+
+Models that need a generic external state/control surface can use the
+`vdm_control` module described in `THIRD-PARTY-CONTROL.md` instead of writing a
+command dispatcher from scratch.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -237,4 +237,22 @@ if(BUILD_TESTS)
   endif()
 
   add_test(NAME vdm_lua_api COMMAND vdm_lua_api_test)
+
+  add_executable(vdm_control_module_test
+    tests/vdm_control_module_test.cc
+    ${SRCDIR}/luabind/vdm_lua_api.cc
+  )
+  target_include_directories(vdm_control_module_test PRIVATE
+    ${SRCDIR}
+    ${CMAKE_SOURCE_DIR}/externals/sdk
+  )
+  target_link_libraries(vdm_control_module_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(vdm_control_module_test PRIVATE /EHsc)
+  endif()
+
+  add_test(
+    NAME vdm_control_module
+    COMMAND vdm_control_module_test "${CMAKE_CURRENT_SOURCE_DIR}/lua/modules/vdm_control.lua"
+  )
 endif()

--- a/model/lua/modules/README.md
+++ b/model/lua/modules/README.md
@@ -1,8 +1,22 @@
-# Lua modules
+# Optional Lua modules
 
-The source modules in this directory can be copied beneath `%LUAVSM%\modules`.
-Load the UART module from a model script and construct it after pin objects
-exist:
+These ordinary Lua 5.4 source modules can be copied beneath
+`%LUAVSM%\modules`. A model can load them directly or add the model root to
+Lua's module search path:
+
+```lua
+local root = assert(os.getenv("LUAVSM"), "LUAVSM is not set")
+package.path = root .. "/?.lua;" .. package.path
+local Control = require("modules.vdm_control")
+```
+
+- `uart.lua` sends 8-N-1 frames through a Lua pin object.
+- `vdm_control.lua` implements a generic, bounded third-party control profile
+  over the Proteus Virtual Debug Monitor transport.
+
+## UART example
+
+Construct the UART module after pin objects exist:
 
 ```lua
 local script_root = assert(os.getenv("LUAVSM"))

--- a/model/lua/modules/vdm_control.lua
+++ b/model/lua/modules/vdm_control.lua
@@ -1,0 +1,145 @@
+local Control = {}
+Control.__index = Control
+
+local TARGET_INFO_FORMAT = "<!4c32I4I4I4I4dI4I4c64"
+
+local function integer(value, name, minimum, maximum)
+    assert(math.type(value) == "integer", name .. " must be an integer")
+    assert(value >= minimum and value <= maximum, name .. " is out of range")
+    return value
+end
+
+local function fixed_string(value, size, name)
+    assert(type(value) == "string", name .. " must be a string")
+    assert(#value <= size, name .. " is too long")
+    return value .. string.rep("\0", size - #value)
+end
+
+function Control.new(options)
+    options = options or {}
+
+    local self = setmetatable({}, Control)
+    self.id = fixed_string(options.id or "OpenVSM", 31, "target ID")
+    self.regclass = integer(options.regclass or 0, "register class", 0, 0xffffffff)
+    self.regsize = integer(options.regsize or 0, "register size", 0, 0xffffffff)
+    self.apiver = integer(options.apiver or VDM_API_VERSION, "API version", 0, 0xffffffff)
+    self.dllver = integer(options.dllver or 0, "DLL version", 0, 0xffffffff)
+    self.clock = options.clock or 0
+    assert(type(self.clock) == "number" and self.clock >= 0, "clock must be a non-negative number")
+    self.specific = fixed_string(options.specific or "", 64, "target-specific data")
+    self.registers = fixed_string(options.registers or "", self.regsize, "register data")
+    self.pc = integer(options.pc or 0, "program counter", 0, 0xffffffff)
+    self.spaces = {}
+    self.breakpoints = {}
+    self.callbacks = {}
+    return self
+end
+
+function Control:register_space(memspace, size, initial)
+    memspace = integer(memspace, "memory space", 0, 0xff)
+    size = integer(size, "memory size", 0, 0xffffffff)
+    initial = initial or ""
+    assert(type(initial) == "string", "initial memory must be a string")
+    assert(#initial <= size, "initial memory is larger than the memory space")
+    self.spaces[memspace] = initial .. string.rep("\0", size - #initial)
+    return self
+end
+
+function Control:read(memspace, address, length)
+    memspace = integer(memspace, "memory space", 0, 0xff)
+    address = integer(address, "address", 0, 0xffffffff)
+    length = integer(length, "length", 0, 0xffffffff)
+    local memory = self.spaces[memspace]
+    if memory == nil or address > #memory or length > #memory - address then
+        return nil, ERR_VDM_BADADDRESS
+    end
+    return memory:sub(address + 1, address + length), ERR_VDM_OK
+end
+
+function Control:write(memspace, address, payload)
+    memspace = integer(memspace, "memory space", 0, 0xff)
+    address = integer(address, "address", 0, 0xffffffff)
+    assert(type(payload) == "string", "payload must be a string")
+    local memory = self.spaces[memspace]
+    if memory == nil or address > #memory or #payload > #memory - address then
+        return ERR_VDM_BADADDRESS
+    end
+    self.spaces[memspace] = memory:sub(1, address) .. payload .. memory:sub(address + #payload + 1)
+    return ERR_VDM_OK
+end
+
+function Control:on(command, callback)
+    command = integer(command, "command", 0, 0xff)
+    assert(type(callback) == "function", "command callback must be a function")
+    self.callbacks[command] = callback
+    return self
+end
+
+function Control:target_info()
+    return string.pack(TARGET_INFO_FORMAT, self.id, self.regclass, self.regsize, self.apiver, self.dllver, self.clock,
+        0, 0, self.specific)
+end
+
+function Control:dispatch(command, memspace, address, length, payload)
+    local callback = self.callbacks[command]
+    if callback ~= nil then
+        local result, response = callback(self, memspace, address, length, payload)
+        if result ~= nil then
+            return result, response
+        end
+    end
+
+    if command == VDM_INIT then
+        return ERR_VDM_OK, self:target_info()
+    elseif command == VDM_TERM or command == VDM_PLAY or command == VDM_STEP or command == VDM_PAUSE or
+        command == VDM_RESET then
+        return ERR_VDM_OK
+    elseif command == VDM_GETTID then
+        return ERR_VDM_OK, fixed_string(self.id, 64, "target ID")
+    elseif command == VDM_READDATA then
+        local response, result = self:read(memspace, address, length)
+        return result, response
+    elseif command == VDM_WRITEDATA then
+        if #payload ~= length then
+            return ERR_VDM_BADDATALEN
+        end
+        return self:write(memspace, address, payload)
+    elseif command == VDM_READREGS then
+        if length > #self.registers then
+            return ERR_VDM_BADDATALEN
+        end
+        return ERR_VDM_OK, self.registers:sub(1, length)
+    elseif command == VDM_WRITEREGS then
+        if length ~= #self.registers or #payload ~= length then
+            return ERR_VDM_BADDATALEN
+        end
+        self.registers = payload
+        return ERR_VDM_OK
+    elseif command == VDM_SETPC then
+        self.pc = integer(address, "program counter", 0, 0xffffffff)
+        return ERR_VDM_OK
+    elseif command == VDM_GETPC then
+        if length < 4 then
+            return ERR_VDM_BADDATALEN
+        end
+        return ERR_VDM_OK, string.pack("<I4", self.pc)
+    elseif command == VDM_SETBP then
+        self.breakpoints[address] = true
+        return ERR_VDM_OK
+    elseif command == VDM_CLRBP then
+        self.breakpoints[address] = nil
+        return ERR_VDM_OK
+    end
+
+    return ERR_VDM_BADCOMMAND
+end
+
+function Control:install()
+    local target = self
+    _G.device_vdm_command = function(command, memspace, address, length, payload)
+        return target:dispatch(command, memspace, address, length, payload)
+    end
+    return self
+end
+
+return Control

--- a/model/tests/vdm_control_module_test.cc
+++ b/model/tests/vdm_control_module_test.cc
@@ -1,0 +1,149 @@
+#include "luabind/vdm_lua_api.hpp"
+
+#include <array>
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+bool expect(bool condition, const char *message)
+{
+    if (!condition)
+    {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+
+LRESULT dispatch(lua_State *lua, BYTE commandCode, BYTE memspace, DWORD address, BYTE *data, DWORD size)
+{
+    VDM_COMMAND command = {commandCode, memspace, address, size};
+    return DeviceSimulator::dispatchLuaVdmCommand(lua, &command, data);
+}
+} // namespace
+
+int main(int argumentCount, char **arguments)
+{
+    if (argumentCount != 2)
+    {
+        std::cerr << "Expected the vdm_control Lua module path\n";
+        return 1;
+    }
+
+    lua_State *lua = luaL_newstate();
+    if (!expect(lua != nullptr, "Lua state creation failed"))
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+    DeviceSimulator::registerVdmLuaApi(lua);
+
+    if (luaL_dofile(lua, arguments[1]) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+    lua_setglobal(lua, "Control");
+
+    bool ok = run(lua, R"(
+        control = Control.new({
+            id = "TEST-TARGET",
+            regclass = VDM51_CLASS,
+            regsize = 4,
+            registers = string.char(1, 2, 3, 4),
+            clock = 12000000,
+            pc = 0x12345678
+        })
+        control:register_space(2, 8, string.char(0x10, 0x20))
+        control:on(VDM_PLAY, function()
+            play_count = (play_count or 0) + 1
+            return ERR_VDM_OK
+        end)
+        control:install()
+    )");
+
+    const int initialTop = lua_gettop(lua);
+    std::array<BYTE, sizeof(VDM_TARGETINFO)> infoBytes = {};
+    ok = expect(dispatch(lua, VDM_INIT, 0, 0, infoBytes.data(), static_cast<DWORD>(infoBytes.size())) == ERR_VDM_OK,
+                "VDM_INIT failed") &&
+         ok;
+    VDM_TARGETINFO info = {};
+    std::memcpy(&info, infoBytes.data(), sizeof(info));
+    ok = expect(std::strcmp(info.id, "TEST-TARGET") == 0, "target ID was not packed") &&
+         expect(info.regclass == VDM51_CLASS, "register class was not packed") &&
+         expect(info.regsize == 4, "register size was not packed") &&
+         expect(info.apiver == VDM_API_VERSION, "VDM API version was not packed") &&
+         expect(info.clock == 12000000, "target clock was not packed") && ok;
+
+    std::array<BYTE, 4> memory = {};
+    ok = expect(dispatch(lua, VDM_READDATA, 2, 0, memory.data(), static_cast<DWORD>(memory.size())) == ERR_VDM_OK,
+                "memory read failed") &&
+         expect(memory == std::array<BYTE, 4>{0x10, 0x20, 0x00, 0x00}, "initial memory contents changed") && ok;
+
+    std::array<BYTE, 2> writeData = {0xaa, 0x00};
+    ok =
+        expect(dispatch(lua, VDM_WRITEDATA, 2, 2, writeData.data(), static_cast<DWORD>(writeData.size())) == ERR_VDM_OK,
+               "binary memory write failed") &&
+        ok;
+    memory = {};
+    ok = expect(dispatch(lua, VDM_READDATA, 2, 0, memory.data(), static_cast<DWORD>(memory.size())) == ERR_VDM_OK,
+                "memory reread failed") &&
+         expect(memory == std::array<BYTE, 4>{0x10, 0x20, 0xaa, 0x00}, "binary memory write was not retained") && ok;
+
+    std::array<BYTE, 2> outside = {};
+    ok = expect(dispatch(lua, VDM_READDATA, 2, 7, outside.data(), static_cast<DWORD>(outside.size())) ==
+                    ERR_VDM_BADADDRESS,
+                "out-of-range memory read was accepted") &&
+         ok;
+
+    std::array<BYTE, 4> registers = {};
+    ok = expect(dispatch(lua, VDM_READREGS, 0, 0, registers.data(), static_cast<DWORD>(registers.size())) == ERR_VDM_OK,
+                "register read failed") &&
+         expect(registers == std::array<BYTE, 4>{1, 2, 3, 4}, "initial registers changed") && ok;
+    registers = {9, 8, 0, 6};
+    ok =
+        expect(dispatch(lua, VDM_WRITEREGS, 0, 0, registers.data(), static_cast<DWORD>(registers.size())) == ERR_VDM_OK,
+               "binary register write failed") &&
+        ok;
+
+    ok = expect(dispatch(lua, VDM_SETPC, 0, 0x89abcdef, nullptr, 0) == ERR_VDM_OK, "VDM_SETPC failed") && ok;
+    std::array<BYTE, 4> pc = {};
+    ok = expect(dispatch(lua, VDM_GETPC, 0, 0, pc.data(), static_cast<DWORD>(pc.size())) == ERR_VDM_OK,
+                "VDM_GETPC failed") &&
+         expect(pc == std::array<BYTE, 4>{0xef, 0xcd, 0xab, 0x89}, "program counter encoding changed") && ok;
+
+    ok = expect(dispatch(lua, VDM_SETBP, 0, 0x1000, nullptr, 0) == ERR_VDM_OK, "VDM_SETBP failed") &&
+         expect(run(lua, "assert(control.breakpoints[0x1000])"), "breakpoint was not recorded") &&
+         expect(dispatch(lua, VDM_CLRBP, 0, 0x1000, nullptr, 0) == ERR_VDM_OK, "VDM_CLRBP failed") &&
+         expect(run(lua, "assert(control.breakpoints[0x1000] == nil)"), "breakpoint was not removed") && ok;
+
+    ok = expect(dispatch(lua, VDM_PLAY, 0, 0, nullptr, 0) == ERR_VDM_OK, "custom play callback failed") &&
+         expect(run(lua, "assert(play_count == 1)"), "custom play callback was not invoked") &&
+         expect(lua_gettop(lua) == initialTop, "control profile changed the Lua stack") && ok;
+
+    std::array<BYTE, 64> targetId = {};
+    ok = expect(dispatch(lua, VDM_GETTID, 0, 0, targetId.data(), static_cast<DWORD>(targetId.size())) == ERR_VDM_OK,
+                "VDM_GETTID failed") &&
+         expect(std::strcmp(reinterpret_cast<const char *>(targetId.data()), "TEST-TARGET") == 0,
+                "VDM_GETTID returned the wrong target") &&
+         ok;
+
+    ok = expect(run(lua, "assert(not pcall(function() Control.new({regsize = 2, registers = 'abc'}) end))"),
+                "oversized register initialization was accepted") &&
+         ok;
+
+    lua_close(lua);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add a reusable Lua `vdm_control` target profile on top of the SDK VDM bridge
- expose fixed-size, range-checked binary memory spaces with NUL-safe reads and writes
- implement target discovery/info, register blocks, PC operations, breakpoints, and standard lifecycle commands
- allow models to override or extend individual VDM commands with deterministic Lua callbacks
- document how third-party tools use Labcenter's existing `vdmapi.dll` transport instead of opening a new unauthenticated model socket

## Dependency

This PR is stacked on #77, which supplies the target-side C++/Lua VDM bridge.

## Validation

- `vdm_control_module_test` passed a packed 128-byte target description, target ID, binary memory/register reads and writes (including NUL bytes), bounds rejection, PC encoding, breakpoints, callback overrides, invalid configuration, and stack balance
- underlying `vdm_lua_api_test` passed
- `luac -p model/lua/modules/vdm_control.lua` passed under bundled Lua 5.4
- `./tools/format.ps1 -Check` passed

A live client test requires the Proteus-distributed `vdmapi.dll` and a running Proteus target, which are not available in the automated environment.

Closes #5