### PR TITLE
Fix per-device pin isolation

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -114,6 +114,11 @@ if(BUILD_TESTS)
   target_link_libraries(pin_registration_stack_test PRIVATE VSM_DLL lua_static)
   add_test(NAME pin_registration_stack COMMAND pin_registration_stack_test)
 
+  add_executable(pin_device_isolation_test tests/pin_device_isolation_test.cc)
+  target_include_directories(pin_device_isolation_test PRIVATE ${SRCDIR})
+  target_link_libraries(pin_device_isolation_test PRIVATE VSM_DLL lua_static)
+  add_test(NAME pin_device_isolation COMMAND pin_device_isolation_test)
+
   add_executable(script_executor_ownership_test
     tests/script_executor_ownership_test.cc
     ${SRCDIR}/luabind/lua_script_executor.cc

--- a/model/cpp/luabind/device/pin.cc
+++ b/model/cpp/luabind/device/pin.cc
@@ -8,31 +8,51 @@
 
 namespace DeviceSimulator
 {
+namespace
+{
+constexpr char nativePinField[] = "__openvsm_native_pin";
+constexpr char dsimField[] = "__openvsm_dsim";
+
+template <typename T> T *requireBoundPointer(lua_State *lua, const char *field, const char *description)
+{
+    luaL_checktype(lua, 1, LUA_TTABLE);
+    lua_getfield(lua, 1, field);
+    auto *pointer = static_cast<T *>(lua_touserdata(lua, -1));
+    lua_pop(lua, 1);
+    if (pointer == nullptr)
+    {
+        luaL_error(lua, "pin is not bound to a native %s", description);
+    }
+    return pointer;
+}
+
+IDSIMPIN *getNativePin(lua_State *lua)
+{
+    return requireBoundPointer<IDSIMPIN>(lua, nativePinField, "Proteus pin");
+}
+
+IDSIMCKT *getNativeDsim(lua_State *lua)
+{
+    return requireBoundPointer<IDSIMCKT>(lua, dsimField, "Proteus simulation context");
+}
+} // namespace
+
 model_pin getPinSelf(lua_State *L)
 {
-    if (!lua_istable(L, -lua_gettop(L)))
-    {
-        LOG_DEBUG("Error: not a table\n");
-        lua_pop(L, 1); // Pop the invalid value from the stack
-        return model_pin{};
-    }
+    luaL_checktype(L, 1, LUA_TTABLE);
 
-    lua_pushstring(L, "pinName");
-    lua_gettable(L, -lua_gettop(L));
+    lua_getfield(L, 1, "pinName");
     std::string pinName = lua_tostring(L, -1);
     lua_pop(L, 1);
-    lua_pushstring(L, "pinNumber");
-    lua_gettable(L, -lua_gettop(L));
+    lua_getfield(L, 1, "pinNumber");
     int pinNumber = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
-    lua_pushstring(L, "onTime");
-    lua_gettable(L, -lua_gettop(L));
+    lua_getfield(L, 1, "onTime");
     const auto onTime = static_cast<RELTIME>(luaL_checkinteger(L, -1));
     lua_pop(L, 1);
 
-    lua_pushstring(L, "offTime");
-    lua_gettable(L, -lua_gettop(L));
+    lua_getfield(L, 1, "offTime");
     const auto offTime = static_cast<RELTIME>(luaL_checkinteger(L, -1));
     lua_pop(L, 1);
 
@@ -44,12 +64,12 @@ model_pin getPinSelf(lua_State *L)
     return pin;
 }
 
-static void setPinState(const model_pin &pin, STATE state)
+static void setPinState(lua_State *lua, const model_pin &pin, STATE state)
 {
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(lua);
+    auto *dsim = getNativeDsim(lua);
     ABSTIME time = 0;
-    device->getDSIM()->systime(&time);
+    dsim->systime(&time);
     pinInstance->setstate(time, transitionDelay(state, pin), state);
 }
 
@@ -60,7 +80,7 @@ static int l_pin_set(lua_State *L)
     int level = luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
-    setPinState(pin, level == 1 ? TSTATE : FSTATE);
+    setPinState(L, pin, level == 1 ? TSTATE : FSTATE);
     return 0;
 }
 
@@ -71,15 +91,14 @@ static int l_pin_set_state(lua_State *L)
     STATE state = (STATE)luaL_checkinteger(L, -1);
     lua_pop(L, 1);
 
-    setPinState(pin, state);
+    setPinState(L, pin, state);
     return 0;
 }
 
 static int l_pin_get(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
 
     auto state = pinInstance->istate();
     lua_pushinteger(L, ishigh(state) ? 1 : 0);
@@ -89,30 +108,29 @@ static int l_pin_get(lua_State *L)
 static int l_pin_set_hi(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    setPinState(pin, TSTATE);
+    setPinState(L, pin, TSTATE);
     return 0;
 }
 
 static int l_pin_set_lo(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    setPinState(pin, FSTATE);
+    setPinState(L, pin, FSTATE);
     return 0;
 }
 
 static int l_pin_invert(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     const auto state = pinInstance->istate();
     if (ishigh(state))
     {
-        setPinState(pin, FSTATE);
+        setPinState(L, pin, FSTATE);
     }
     else if (islow(state))
     {
-        setPinState(pin, TSTATE);
+        setPinState(L, pin, TSTATE);
     }
     else
     {
@@ -124,8 +142,7 @@ static int l_pin_invert(lua_State *L)
 static int l_pint_issteady(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->issteady());
     return 1;
 }
@@ -133,8 +150,7 @@ static int l_pint_issteady(lua_State *L)
 static int l_pin_activity(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushinteger(L, pinInstance->activity());
     return 1;
 }
@@ -142,8 +158,7 @@ static int l_pin_activity(lua_State *L)
 static int l_pin_isactive(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->isactive());
     return 1;
 }
@@ -151,8 +166,7 @@ static int l_pin_isactive(lua_State *L)
 static int l_pin_isinactive(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->isinactive());
     return 1;
 }
@@ -160,8 +174,7 @@ static int l_pin_isinactive(lua_State *L)
 static int l_pin_isposedge(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->isposedge());
     return 1;
 }
@@ -169,8 +182,7 @@ static int l_pin_isposedge(lua_State *L)
 static int l_pin_isnegedge(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->isnegedge());
     return 1;
 }
@@ -178,8 +190,7 @@ static int l_pin_isnegedge(lua_State *L)
 static int l_pin_isedge(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     lua_pushboolean(L, pinInstance->isedge());
     return 1;
 }
@@ -187,8 +198,7 @@ static int l_pin_isedge(lua_State *L)
 static int l_pin_islow(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, islow(state));
     return 1;
@@ -197,8 +207,7 @@ static int l_pin_islow(lua_State *L)
 static int l_pin_ishigh(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, ishigh(state));
     return 1;
@@ -207,8 +216,7 @@ static int l_pin_ishigh(lua_State *L)
 static int l_pin_isfloating(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, isfloating(state));
     return 1;
@@ -217,8 +225,7 @@ static int l_pin_isfloating(lua_State *L)
 static int l_pin_iscontention(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, iscontention(state));
     return 1;
@@ -227,8 +234,7 @@ static int l_pin_iscontention(lua_State *L)
 static int l_pin_isdefined(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, isdefined(state));
     return 1;
@@ -237,8 +243,7 @@ static int l_pin_isdefined(lua_State *L)
 static int l_pin_ishighlow(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushboolean(L, ishighlow(state));
     return 1;
@@ -247,8 +252,7 @@ static int l_pin_ishighlow(lua_State *L)
 static int l_pin_polarity(lua_State *L)
 {
     auto pin = getPinSelf(L);
-    auto device = VirtualContextManager::getInstance().getDevice();
-    auto pinInstance = device->getPin(const_cast<CHAR *>(pin.name.c_str()));
+    auto *pinInstance = getNativePin(L);
     auto state = pinInstance->istate();
     lua_pushinteger(L, polarity(state));
     return 1;
@@ -279,7 +283,7 @@ static const luaL_Reg VsmPinMethodsLib[] = {{"set", l_pin_set},
 namespace
 {
 void registerPinLibrary(lua_State *luaContext, const model_pin &pin, IDSIMPIN *nativePin = nullptr,
-                        LuaEventDispatcher *dispatcher = nullptr)
+                        IDSIMCKT *dsim = nullptr, LuaEventDispatcher *dispatcher = nullptr)
 {
     LuaScripting::LuaStackGuard stackGuard(luaContext);
     luaL_newlib(luaContext, VsmPinMethodsLib);
@@ -287,6 +291,18 @@ void registerPinLibrary(lua_State *luaContext, const model_pin &pin, IDSIMPIN *n
     if (nativePin != nullptr && dispatcher != nullptr)
     {
         attachPinCallbackApi(luaContext, -1, nativePin, dispatcher);
+    }
+
+    if (nativePin != nullptr)
+    {
+        lua_pushlightuserdata(luaContext, nativePin);
+        lua_setfield(luaContext, -2, nativePinField);
+    }
+
+    if (dsim != nullptr)
+    {
+        lua_pushlightuserdata(luaContext, dsim);
+        lua_setfield(luaContext, -2, dsimField);
     }
 
     lua_pushinteger(luaContext, pin.number);
@@ -310,9 +326,14 @@ void registerPinLibrary(lua_State *luaContext, const char *name, int number)
     registerPinLibrary(luaContext, model_pin{name, number, 0, 0});
 }
 
+void registerPinLibrary(lua_State *luaContext, const char *name, int number, IDSIMPIN *nativePin, IDSIMCKT *dsim)
+{
+    registerPinLibrary(luaContext, model_pin{name, number, 0, 0}, nativePin, dsim);
+}
+
 void VirtualDevice::registerPin(const model_pin &pin)
 {
     LOG_DEBUG("Registering pin {}-{}\n", pin.name, pin.number);
-    registerPinLibrary(luactx_, pin, getPin(const_cast<CHAR *>(pin.name.c_str())), eventDispatcher_.get());
+    registerPinLibrary(luactx_, pin, getPin(const_cast<CHAR *>(pin.name.c_str())), dsim_, eventDispatcher_.get());
 }
 } // namespace DeviceSimulator

--- a/model/cpp/luabind/device/pin.hpp
+++ b/model/cpp/luabind/device/pin.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <lua.hpp>
+#include <vsm.hpp>
 
 namespace DeviceSimulator
 {
 void registerPinLibrary(lua_State *luaContext, const char *name, int number);
+void registerPinLibrary(lua_State *luaContext, const char *name, int number, IDSIMPIN *nativePin, IDSIMCKT *dsim);
 } // namespace DeviceSimulator

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -46,12 +46,6 @@ namespace DeviceSimulator
 #define PIN_OFF_TIME "off_time"
 #define PIN_ON_TIME "on_time"
 
-VirtualContextManager &VirtualContextManager::getInstance()
-{
-    static VirtualContextManager instance;
-    return instance;
-}
-
 VirtualDevice::VirtualDevice()
 {
     LOG_DEBUG("Creating the device\n");
@@ -88,7 +82,6 @@ VirtualDevice::VirtualDevice()
 VirtualDevice::~VirtualDevice()
 {
     LOG_DEBUG("Destroying the device\n");
-    VirtualContextManager::getInstance().unregisterDevice(*this);
     eventDispatcher_.reset();
     lua_close(luactx_);
 }
@@ -103,10 +96,8 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
 {
     modelReady_ = false;
     LuaScripting::LuaStackGuard stackGuard(luactx_);
-    auto &mgr = VirtualContextManager::getInstance();
     dsim_ = dsim;
     instance_ = instance;
-    mgr.registerDevice(instance_->id(), *this);
     deviceID_ = instance_->id();
     GUID guid;
     CoCreateGuid(&guid);
@@ -185,7 +176,6 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
         return;
     }
 
-    mgr.setCurrentDevice(deviceID_);
     const auto initialization = LuaScripting::invokeCallback(luactx_, "device_init");
     if (initialization.status == LuaScripting::CallbackStatus::succeeded)
     {
@@ -264,8 +254,6 @@ void VirtualDevice::simulate(ABSTIME time, DSIMMODES mode)
         return;
     }
 
-    auto &vinstance = VirtualContextManager::getInstance();
-    vinstance.setCurrentDevice(deviceID_);
     eventDispatcher_->dispatch(time, mode);
 
     lua_getglobal(luactx_, "device_simulate");
@@ -292,9 +280,6 @@ void VirtualDevice::callback(ABSTIME time, EVENTID eventid)
     {
         return;
     }
-
-    auto &vinstance = VirtualContextManager::getInstance();
-    vinstance.setCurrentDevice(deviceID_);
 
     const auto callback = LuaScripting::invokeCallback(
         luactx_, "timer_callback", {static_cast<lua_Integer>(time), static_cast<lua_Integer>(eventid)});
@@ -326,54 +311,4 @@ BOOL VirtualDevice::getvardata(VARITEM *item, VARDATA *data)
     return FALSE;
 }
 
-const lua_State *VirtualContextManager::getDeviceLuaContext(const std::string &id)
-{
-    if (devices_.find(id) != devices_.end())
-    {
-        VirtualDevice *device = devices_[id];
-        return device->getLuaContext();
-    }
-    return nullptr;
-}
-
-const VirtualDevice *VirtualContextManager::getDevice(const std::string &id)
-{
-    if (devices_.find(id) != devices_.end())
-    {
-        return devices_[id];
-    }
-    return nullptr;
-}
-
-const VirtualDevice *VirtualContextManager::getDevice()
-{
-    if (devices_.find(currentDevice_) != devices_.end())
-    {
-        return devices_[currentDevice_];
-    }
-    return nullptr;
-}
-
-void VirtualContextManager::registerDevice(std::string id, VirtualDevice &device)
-{
-    devices_[id] = &device;
-}
-void VirtualContextManager::unregisterDevice(const VirtualDevice &device)
-{
-    for (auto deviceIt = devices_.begin(); deviceIt != devices_.end();)
-    {
-        if (deviceIt->second == &device)
-        {
-            if (currentDevice_ == deviceIt->first)
-            {
-                currentDevice_.clear();
-            }
-            deviceIt = devices_.erase(deviceIt);
-        }
-        else
-        {
-            ++deviceIt;
-        }
-    }
-}
 } // namespace DeviceSimulator

--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -100,41 +99,4 @@ class VirtualDevice : public IDSIMMODEL, public ICPU
     std::unique_ptr<LuaEventDispatcher> eventDispatcher_;
 };
 
-/** Registry used by native Lua functions to locate the active model instance.
- *
- * Registered pointers are non-owning. Model lifetime remains with the exported
- * factory/deleter contract.
- */
-class VirtualContextManager
-{
-  public:
-    /** Return the process-wide context registry. */
-    static VirtualContextManager &getInstance();
-
-    VirtualContextManager(VirtualContextManager const &) = delete;
-    void operator=(VirtualContextManager const &) = delete;
-
-    /** Find a registered device by Proteus instance ID, or return nullptr. */
-    const VirtualDevice *getDevice(const std::string &id);
-    /** Return the active device, or nullptr when no registered device is active. */
-    const VirtualDevice *getDevice();
-    /** Return a registered device's non-owning Lua state, or nullptr. */
-    const lua_State *getDeviceLuaContext(const std::string &id);
-    /** Register a non-owning device pointer under its Proteus instance ID. */
-    void registerDevice(std::string id, VirtualDevice &device);
-    /** Remove every registry entry that points to the given device. */
-    void unregisterDevice(const VirtualDevice &device);
-    /** Select the device whose native Lua calls are currently being dispatched. */
-    void setCurrentDevice(const std::string &id)
-    {
-        currentDevice_ = id;
-    }
-
-  private:
-    VirtualContextManager() {};
-
-    std::string currentDevice_;
-    std::map<std::string, VirtualDevice *> devices_;
-    lua_State *luactx_;
-};
 } // namespace DeviceSimulator

--- a/model/tests/model_deletion_test.cc
+++ b/model/tests/model_deletion_test.cc
@@ -1,5 +1,3 @@
-#include <string>
-#include <vector>
 #include "model.hpp"
 #include <lua.hpp>
 
@@ -31,14 +29,10 @@ int main()
 {
     deletedsimmodel(nullptr);
 
-    auto &manager = DeviceSimulator::VirtualContextManager::getInstance();
     constexpr int iterations = 64;
     for (int iteration = 0; iteration < iterations; ++iteration)
     {
         auto *device = new DeviceSimulator::VirtualDevice;
-        const std::string id = "deletion-test-" + std::to_string(iteration);
-        manager.registerDevice(id, *device);
-        manager.setCurrentDevice(id);
         installFinalizer(device->getLuaContext());
 
         IDSIMMODEL *baseModel = device;
@@ -48,15 +42,7 @@ int main()
         {
             return 1;
         }
-        if (manager.getDevice(id) != nullptr)
-        {
-            return 2;
-        }
-        if (manager.getDevice() != nullptr)
-        {
-            return 3;
-        }
     }
 
-    return finalizerCalls == iterations ? 0 : 4;
+    return finalizerCalls == iterations ? 0 : 2;
 }

--- a/model/tests/pin_device_isolation_test.cc
+++ b/model/tests/pin_device_isolation_test.cc
@@ -1,0 +1,197 @@
+#include "luabind/device/pin.hpp"
+
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+class FakeDsim final : public IDSIMCKT
+{
+  public:
+    explicit FakeDsim(ABSTIME simulationTime) : time(simulationTime)
+    {
+    }
+
+    ABSTIME time;
+
+    void sysvar(DOUBLE *result, DSIMVARS variable) override
+    {
+        if (variable == DSIMTIMENOW)
+        {
+            std::memcpy(result, &time, sizeof(time));
+        }
+    }
+
+    EVENT *setcallback(ABSTIME, IDSIMMODEL *, EVENTID) override
+    {
+        return nullptr;
+    }
+    BOOL cancelcallback(EVENT *, IDSIMMODEL *) override
+    {
+        return FALSE;
+    }
+    void setbreak(ABSTIME) override
+    {
+    }
+    void suspend(IINSTANCE *, CHAR *) override
+    {
+    }
+    EVENT *setcallbackex(ABSTIME, IDSIMMODEL *, CALLBACKHANDLERFN, EVENTID) override
+    {
+        return nullptr;
+    }
+    DSIMNODE newnode(CHAR *, CHAR *) override
+    {
+        return nullptr;
+    }
+    IDSIMPIN *newpin(IINSTANCE *, DSIMNODE, CHAR *, DWORD) override
+    {
+        return nullptr;
+    }
+    EVENT *setclockcallback(ABSTIME, RELTIME, IDSIMMODEL *, CALLBACKHANDLERFN, EVENTID) override
+    {
+        return nullptr;
+    }
+};
+
+class FakePin final : public IDSIMPIN
+{
+  public:
+    STATE state = SLO;
+    ABSTIME lastTime = -1;
+    RELTIME lastDelay = -1;
+
+    BOOL invert() override
+    {
+        state = ishigh(state) ? SLO : SHI;
+        return TRUE;
+    }
+    STATE istate() override
+    {
+        return state;
+    }
+    BOOL issteady() override
+    {
+        return TRUE;
+    }
+    INT activity() override
+    {
+        return 0;
+    }
+    BOOL isactive() override
+    {
+        return FALSE;
+    }
+    BOOL isinactive() override
+    {
+        return TRUE;
+    }
+    BOOL isposedge() override
+    {
+        return FALSE;
+    }
+    BOOL isnegedge() override
+    {
+        return FALSE;
+    }
+    BOOL isedge() override
+    {
+        return FALSE;
+    }
+    EVENT *setstate(ABSTIME, RELTIME, RELTIME, RELTIME, STATE) override
+    {
+        return nullptr;
+    }
+    EVENT *setstate(ABSTIME time, RELTIME delay, STATE newState) override
+    {
+        lastTime = time;
+        lastDelay = delay;
+        state = newState;
+        return nullptr;
+    }
+    void setstate(STATE newState) override
+    {
+        state = newState;
+    }
+    void sethandler(IDSIMMODEL *, PINHANDLERFN) override
+    {
+    }
+    DSIMNODE getnode() override
+    {
+        return nullptr;
+    }
+    STATE getstate() override
+    {
+        return state;
+    }
+    void settiming(RELTIME, RELTIME, RELTIME) override
+    {
+    }
+    void setstates(STATE, STATE, STATE) override
+    {
+    }
+    EVENT *drivebool(ABSTIME, BOOL) override
+    {
+        return nullptr;
+    }
+    EVENT *drivestate(ABSTIME, STATE) override
+    {
+        return nullptr;
+    }
+    EVENT *drivetristate(ABSTIME) override
+    {
+        return nullptr;
+    }
+};
+
+bool run(lua_State *lua, const char *script)
+{
+    if (luaL_dostring(lua, script) == LUA_OK)
+    {
+        return true;
+    }
+    std::cerr << lua_tostring(lua, -1) << '\n';
+    lua_pop(lua, 1);
+    return false;
+}
+} // namespace
+
+int main()
+{
+    auto *luaA = luaL_newstate();
+    auto *luaB = luaL_newstate();
+    if (luaA == nullptr || luaB == nullptr)
+    {
+        if (luaA != nullptr)
+        {
+            lua_close(luaA);
+        }
+        if (luaB != nullptr)
+        {
+            lua_close(luaB);
+        }
+        return 1;
+    }
+    luaL_openlibs(luaA);
+    luaL_openlibs(luaB);
+
+    FakeDsim dsimA{101};
+    FakeDsim dsimB{202};
+    FakePin pinA;
+    FakePin pinB;
+    pinB.state = SHI;
+
+    DeviceSimulator::registerPinLibrary(luaA, "IO", 1, &pinA, &dsimA);
+    DeviceSimulator::registerPinLibrary(luaB, "IO", 1, &pinB, &dsimB);
+
+    const bool firstDeviceOk = run(luaA, "assert(IO:get() == 0); IO:hi()") && pinA.state == TSTATE &&
+                               pinA.lastTime == dsimA.time && pinB.state == SHI && pinB.lastTime == -1;
+    const bool secondDeviceOk = run(luaB, "assert(IO:get() == 1); IO:lo()") && pinB.state == FSTATE &&
+                                pinB.lastTime == dsimB.time && pinA.state == TSTATE;
+    const bool interleavedOk = run(luaA, "IO:lo()") && run(luaB, "IO:hi()") && pinA.state == FSTATE &&
+                               pinB.state == TSTATE && pinA.lastTime == dsimA.time && pinB.lastTime == dsimB.time;
+
+    lua_close(luaA);
+    lua_close(luaB);
+    return firstDeviceOk && secondDeviceOk && interleavedOk ? 0 : 2;
+}


### PR DESCRIPTION
## What changed

- bind every Lua pin table directly to its owning Proteus `IDSIMPIN` and `IDSIMCKT`
- remove the process-global current-device registry and callback-time device switching
- add a regression test with two independent Lua states using the same pin name and interleaved operations
- keep deletion coverage focused on Lua-state ownership after removing the obsolete registry

## Why

Pin methods previously resolved their owner through one DLL-wide `currentDevice_` value. Graphics, VDM, reentrant, or concurrent callbacks could therefore operate on another component's pin. Direct bindings make ownership independent of callback ordering.

## Validation

Passed in Release:

- `pin_device_isolation`
- `pin_registration_stack`
- `model_deletion`
- `model_authorization`

The repository-wide test build still has unrelated baseline failures: several standalone test targets do not request C++17/20, `vsm_lua_api_test` has an existing const mismatch, and `simulation_stack` expects callbacks before model setup marks the model ready.