### PR TITLE
Preserve existing LUAVSM configuration

### DIFF
--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -13,6 +13,10 @@ The installer is written below `.build/installer/installer`. A normal OpenVSM
 configure/build leaves `DLL_WITH_INSTALLER` disabled and does not require Inno
 Setup.
 
+Setup creates the machine-wide `LUAVSM` environment variable only when it is
+absent. A pre-existing value is left unchanged. On uninstall, Setup removes
+`LUAVSM` only when it created the value and the user has not changed it since.
+
 Release builds can sign both `openvsm.dll` and the generated installer with a
 certificate from the Windows certificate store:
 

--- a/externals/installer/openvsm.iss
+++ b/externals/installer/openvsm.iss
@@ -41,16 +41,64 @@ Source: "{#OpenVsmDllPath}"; DestDir: "{code:GetProteusInstallDir}\Models"; Dest
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 
 [Registry]
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "LUAVSM"; ValueData: "{app}\LuaScripts"; Flags: deletevalue
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "LUAVSM"; ValueData: "{app}\LuaScripts"; Flags: preservestringtype; Check: ShouldManageLuaVsm
+Root: HKLM; Subkey: "SOFTWARE\432 Works\OpenVSM"; ValueType: expandsz; ValueName: "InstallerLuaVsm"; ValueData: "{app}\LuaScripts"; Flags: uninsdeletevalue uninsdeletekeyifempty; Check: ShouldManageLuaVsm
 
 [Dirs]
 Name: "{app}\LuaScripts"; Flags: uninsneveruninstall
 
 [Messages]
 BeveledLabel=OpenVSM
-FinishedLabel=The default folder for model scripts is LuaScripts inside the OpenVSM installation directory.%nChange the LUAVSM user environment variable to use another folder.
+FinishedLabel=The default folder for model scripts is LuaScripts inside the OpenVSM installation directory.%nAn existing LUAVSM environment variable is preserved.
 
 [Code]
+const
+  EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+  InstallerKey = 'SOFTWARE\432 Works\OpenVSM';
+
+var
+  LuaVsmDecisionMade: Boolean;
+  ManageLuaVsm: Boolean;
+
+function SamePath(const Left, Right: string): Boolean;
+begin
+  Result := CompareText(RemoveBackslashUnlessRoot(Left), RemoveBackslashUnlessRoot(Right)) = 0;
+end;
+
+function ShouldManageLuaVsm(): Boolean;
+var
+  ExistingValue: string;
+  InstallerValue: string;
+begin
+  if not LuaVsmDecisionMade then
+  begin
+    LuaVsmDecisionMade := True;
+    ManageLuaVsm := not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'LUAVSM', ExistingValue);
+
+    if (not ManageLuaVsm) and
+       RegQueryStringValue(HKEY_LOCAL_MACHINE, InstallerKey, 'InstallerLuaVsm', InstallerValue) then
+    begin
+      ManageLuaVsm := SamePath(ExistingValue, InstallerValue);
+    end;
+  end;
+
+  Result := ManageLuaVsm;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  ExistingValue: string;
+  InstallerValue: string;
+begin
+  if (CurUninstallStep = usUninstall) and
+     RegQueryStringValue(HKEY_LOCAL_MACHINE, InstallerKey, 'InstallerLuaVsm', InstallerValue) and
+     RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'LUAVSM', ExistingValue) and
+     SamePath(ExistingValue, InstallerValue) then
+  begin
+    RegDeleteValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'LUAVSM');
+  end;
+end;
+
 function GetProteusInstallDir(Value: string): string;
 var
   InstallPath: string;


### PR DESCRIPTION
## What changed

- preserve a pre-existing machine-wide `LUAVSM` value
- record installer ownership only when Setup creates `LUAVSM`
- remove the value during uninstall only when it is still unchanged and installer-owned
- preserve user changes made after installation
- correct the completion text and document the lifecycle

## Why

The previous `deletevalue` flag erased any existing model-script path during installation and left the replacement behind after uninstall. On the audited machine that would overwrite `C:\Dev\proteus_lua_script`.

## Validation

- Release `BuildInstaller` target completed successfully
- Inno Setup 6.2.2 compiled `openvsm-0.19-setup.exe`
- the installer was not executed, so the current Proteus installation and registry were not modified