### PR TITLE
Validate the Proteus Models directory

### DIFF
--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -29,3 +29,8 @@ cmake --build .build/signed --config Release --target BuildInstaller
 Set `OPENVSM_SIGNTOOL` when `signtool.exe` is not on `PATH` or in the standard
 Windows SDK directory. `OPENVSM_SIGN_TIMESTAMP_URL` selects the RFC 3161
 timestamp service and defaults to DigiCert.
+
+Setup detects Proteus 7 or 8 Professional from the registry and displays the
+resulting Models directory for confirmation. If registry detection fails, the
+user must select an existing Proteus Models directory; Setup does not silently
+install model DLLs into the OpenVSM application directory.

--- a/externals/installer/openvsm.iss
+++ b/externals/installer/openvsm.iss
@@ -35,7 +35,7 @@ SolidCompression=yes
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "{#OpenVsmDllPath}"; DestDir: "{code:GetProteusInstallDir}\Models"; DestName: "openvsm.dll"; Flags: ignoreversion
+Source: "{#OpenVsmDllPath}"; DestDir: "{code:GetProteusModelsDir}"; DestName: "openvsm.dll"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
@@ -59,6 +59,7 @@ const
 var
   LuaVsmDecisionMade: Boolean;
   ManageLuaVsm: Boolean;
+  ProteusModelsPage: TInputDirWizardPage;
 
 function SamePath(const Left, Right: string): Boolean;
 begin
@@ -99,11 +100,11 @@ begin
   end;
 end;
 
-function GetProteusInstallDir(Value: string): string;
+function GetDetectedProteusInstallDir(): string;
 var
   InstallPath: string;
 begin
-  Result := ExpandConstant('{app}');
+  Result := '';
 
   if RegQueryStringValue(HKEY_LOCAL_MACHINE,
     'SOFTWARE\Wow6432Node\Labcenter Electronics\Proteus 8 Professional',
@@ -134,5 +135,57 @@ begin
     'Path', InstallPath) then
   begin
     Result := InstallPath;
+  end;
+end;
+
+function GetProteusModelsDir(Value: string): string;
+begin
+  Result := ProteusModelsPage.Values[0];
+end;
+
+function ValidateProteusModelsDir(): Boolean;
+var
+  ModelsDir: string;
+begin
+  ModelsDir := GetProteusModelsDir('');
+  Result := (ModelsDir <> '') and DirExists(ModelsDir);
+end;
+
+procedure InitializeWizard();
+var
+  InstallDir: string;
+begin
+  ProteusModelsPage := CreateInputDirPage(
+    wpSelectDir,
+    'Select the Proteus Models directory',
+    'Choose the Models directory used by Proteus.',
+    'Setup detected the directory below. If it is incorrect, select the Models directory for the Proteus installation that should load OpenVSM.',
+    False,
+    '');
+  ProteusModelsPage.Add('');
+
+  InstallDir := GetDetectedProteusInstallDir();
+  if InstallDir <> '' then
+  begin
+    ProteusModelsPage.Values[0] := AddBackslash(InstallDir) + 'Models';
+  end;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if (CurPageID = ProteusModelsPage.ID) and not ValidateProteusModelsDir() then
+  begin
+    MsgBox('Select an existing Proteus Models directory before continuing.', mbError, MB_OK);
+    Result := False;
+  end;
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := '';
+  if not ValidateProteusModelsDir() then
+  begin
+    Result := 'A valid Proteus Models directory is required. Setup cannot continue.';
   end;
 end;


### PR DESCRIPTION
## What changed

- detect the Proteus 7/8 Professional install path and derive its Models directory
- show the detected directory on a dedicated wizard page
- allow manual selection for nonstandard or unregistered installations
- reject missing or nonexistent Models directories in interactive and silent installs
- install both DLLs directly into the validated directory

## Why

When registry detection previously failed, Setup silently fell back to `{app}` and installed into `OpenVSM\Models`, where Proteus would not load the model.

## Validation

- Release `BuildInstaller` target completed successfully
- Inno Setup 6.2.2 compiled `openvsm-0.19-setup.exe`
- local registry detection resolves to the installed Proteus 8 Professional Models directory
- the installer was not executed, so the local Proteus installation was not modified