### PR TITLE
Build a self-contained OpenVSM DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.21)
 
 project(OpenVSM)
 
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/model/VERSION.txt" OPENVSM_VERSION)
 option(DLL_WITH_INSTALLER "Enable the Inno Setup installer target" OFF)
 option(BUILD_DOCS "Build the Doxygen developer reference" OFF)
@@ -60,13 +64,12 @@ if(DLL_WITH_INSTALLER)
                     COMMAND "${INNO_SETUP_COMPILER}"
                             "/DOpenVsmVersion=${OPENVSM_VERSION}"
                             "/DOpenVsmDllPath=$<TARGET_FILE:VSM_DLL>"
-                            "/DOpenVsmLoggerPath=$<TARGET_FILE:tinyLog>"
                             "/DOpenVsmOutputDir=${INNO_SETUP_OUTPUT_DIR}"
                             "${INNO_SETUP_SCRIPT_PATH}"
                     COMMENT "Building the OpenVSM installer"
                     VERBATIM
   )
-  add_dependencies(BuildInstaller VSM_DLL tinyLog)
+  add_dependencies(BuildInstaller VSM_DLL)
 endif()
 
 target_include_directories(VSM_DLL PUBLIC externals)

--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -1,7 +1,7 @@
 # OpenVSM installer
 
 The Inno Setup script is built through CMake so it receives the selected
-configuration's `openvsm.dll` and `logger.dll` paths and the version from
+configuration's self-contained `openvsm.dll` path and the version from
 `model/VERSION.txt`.
 
 ```powershell

--- a/externals/installer/openvsm.iss
+++ b/externals/installer/openvsm.iss
@@ -4,9 +4,6 @@
 #ifndef OpenVsmDllPath
   #define OpenVsmDllPath "..\..\dll\openvsm.dll"
 #endif
-#ifndef OpenVsmLoggerPath
-  #define OpenVsmLoggerPath "..\..\dll\logger.dll"
-#endif
 #ifndef OpenVsmOutputDir
   #define OpenVsmOutputDir "."
 #endif
@@ -39,7 +36,6 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 Source: "{#OpenVsmDllPath}"; DestDir: "{code:GetProteusInstallDir}\Models"; DestName: "openvsm.dll"; Flags: ignoreversion
-Source: "{#OpenVsmLoggerPath}"; DestDir: "{code:GetProteusInstallDir}\Models"; DestName: "logger.dll"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"


### PR DESCRIPTION
## What changed

- link TinyLog statically into `openvsm.dll`
- use the static MSVC runtime for the Win32 build
- remove `logger.dll` from the installer inputs and payload
- update the TinyLog submodule to Pugnator/TinyLog#2

## Why

The previous package required a generically named `logger.dll` plus an externally installed x86 VC++ runtime. In Proteus's shared model-loading process that creates both module-name collision risk and clean-machine deployment failures.

## Result

The Win32 Release `openvsm.dll` now imports only:

- `KERNEL32.dll`
- `ole32.dll`

It no longer imports `logger.dll`, `MSVCP140.dll`, `VCRUNTIME140.dll`, or Universal CRT DLLs. The installer contains a single model DLL.

## Validation

- clean Win32 Release configure and `BuildInstaller` completed successfully
- Inno Setup 6.2.2 compiled `openvsm-0.19-setup.exe`
- `dumpbin /headers` confirms x86
- `dumpbin /exports` confirms all four Proteus factory/deleter exports
- `dumpbin /dependents` confirms only Windows system DLL dependencies

Depends on Pugnator/TinyLog#2, whose commit is already available at the submodule SHA.