### PR TITLE
Move logging initialization out of DllMain

### DIFF
--- a/model/cpp/dllmain.cc
+++ b/model/cpp/dllmain.cc
@@ -1,6 +1,5 @@
 #include <windows.h>
-#include <stdint.h>
-#include <stdbool.h>
+#include <fstream>
 #include <vsm.hpp>
 #include <log/log.hpp>
 #include "active_model.hpp"
@@ -12,12 +11,49 @@ bool vsmRegister(ILICENCESERVER *ils)
 {
     return ils && ils->authorize(0, VSM_API_VERSION);
 }
+
+void initializeRuntimeLogging() noexcept
+{
+    static const bool initialized = []() noexcept
+    {
+        try
+        {
+            std::ofstream logProbe("log.txt", std::ios::app);
+            if (logProbe.is_open())
+            {
+                logProbe.close();
+                Log::get().configure(TraceType::file);
+            }
+            else
+            {
+                Log::get().configure(TraceType::devnull);
+            }
+#ifdef OPENVSM_DEBUG
+            Log::get().set_level(TraceSeverity::debug);
+#endif
+            LOG_DEBUG("The model is being loaded\n");
+        }
+        catch (...)
+        {
+            try
+            {
+                Log::get().configure(TraceType::devnull);
+            }
+            catch (...)
+            {
+            }
+        }
+        return true;
+    }();
+    (void)initialized;
+}
 } // namespace
 
 extern "C"
 {
     IACTIVEMODEL __declspec(dllexport) * createactivemodel(char *device, ILICENCESERVER *ils)
     {
+        initializeRuntimeLogging();
         (void)device;
         if (!ils || !vsmRegister(ils))
         {
@@ -33,6 +69,7 @@ extern "C"
 
     IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
     {
+        initializeRuntimeLogging();
         (void)device;
         if (!vsmRegister(ils))
         {
@@ -57,29 +94,4 @@ extern "C"
         }
         delete device;
     }
-}
-
-bool APIENTRY DllMain(HINSTANCE hInstDLL, uint32_t fdwReason, LPVOID lpvReserved)
-{
-    switch (fdwReason)
-    {
-    case DLL_PROCESS_ATTACH:
-        Log::get().configure(TraceType::file);
-        Log::get().set_level(TraceSeverity::debug);
-        LOG_DEBUG("The model is being loaded\n");
-        break;
-    case DLL_PROCESS_DETACH:
-        LOG_DEBUG("The model is being unloaded\n");
-        break;
-    case DLL_THREAD_ATTACH:
-        LOG_DEBUG("A thread is being created\n");
-        break;
-    case DLL_THREAD_DETACH:
-        LOG_DEBUG("A thread is being destroyed\n");
-        break;
-    }
-    (void)hInstDLL;
-    (void)fdwReason;
-    (void)lpvReserved;
-    return true;
 }


### PR DESCRIPTION
## What changed

- remove the custom `DllMain` implementation and all process/thread notification logging
- initialize logging once, on the first Proteus model factory call
- probe whether `log.txt` is writable before selecting the file sink
- fall back to the null sink on unwritable paths or logger initialization failures
- enable debug verbosity only in debug builds

## Why

The previous DLL entry point opened and wrote a file, initialized C++ logger state, took locks, and could throw while Windows held the loader lock. That could deadlock Proteus or fail DLL loading before a model factory was called.

## Validation

- Win32 Release `model_authorization_test` target builds
- `model_authorization` passes under CTest
- the test executable exits successfully when launched with `C:\Windows\System32` as its current directory
- the protected-directory run produces no logging error and does not create a file there