### PR TITLE
Make model destruction polymorphic

### DIFF
--- a/model/cpp/model.hpp
+++ b/model/cpp/model.hpp
@@ -32,8 +32,8 @@ class VirtualDevice : public IDSIMMODEL, public ICPU
   public:
     /** Allocate and initialize the model's Lua state. */
     VirtualDevice();
-    /** Close the owned Lua state. */
-    ~VirtualDevice();
+    /** Close the owned Lua state, including when deleted through this base class. */
+    virtual ~VirtualDevice();
 
     /** Report that a component terminal uses the digital simulation engine. */
     INT isdigital(CHAR *pinname) override;

--- a/model/tests/model_deletion_test.cc
+++ b/model/tests/model_deletion_test.cc
@@ -1,3 +1,5 @@
+#include <type_traits>
+#include "active_model.hpp"
 #include "model.hpp"
 #include <lua.hpp>
 
@@ -5,6 +7,8 @@ extern "C" void deletedsimmodel(IDSIMMODEL *model);
 
 namespace
 {
+static_assert(std::has_virtual_destructor_v<DeviceSimulator::VirtualDevice>);
+
 int finalizerCalls = 0;
 
 int countFinalizer(lua_State *luaContext)
@@ -44,5 +48,9 @@ int main()
         }
     }
 
-    return finalizerCalls == iterations ? 0 : 2;
+    auto *activeModel = new DeviceSimulator::LuaActiveModel;
+    installFinalizer(activeModel->getLuaContext());
+    deletedsimmodel(activeModel->getdsimmodel(nullptr));
+
+    return finalizerCalls == iterations + 1 ? 0 : 2;
 }


### PR DESCRIPTION
## What changed

- make `VirtualDevice` destruction virtual
- add a compile-time virtual-destructor assertion
- exercise deletion of `LuaActiveModel` through the `IDSIMMODEL` interface
- verify the derived model's Lua-owned resource is finalized

## Why

`LuaActiveModel::getdsimmodel()` returns the derived object as `IDSIMMODEL`. `deletedsimmodel()` then converts that interface to `VirtualDevice*`; deleting through a non-virtual base was undefined behavior for an active model.

## Validation

- Win32 Release `model_deletion_test` target builds
- `model_deletion` passes under CTest
- the existing repeated DSim deletion coverage remains intact