### PR TITLE
Give each device a unique Lua random seed

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -132,6 +132,11 @@ if(BUILD_TESTS)
   target_link_libraries(simulation_stack_test PRIVATE VSM_DLL lua_static)
   add_test(NAME simulation_stack COMMAND simulation_stack_test)
 
+  add_executable(random_seed_test tests/random_seed_test.cc)
+  target_include_directories(random_seed_test PRIVATE ${SRCDIR})
+  target_link_libraries(random_seed_test PRIVATE VSM_DLL lua_static)
+  add_test(NAME random_seed COMMAND random_seed_test)
+
   add_executable(model_deletion_test tests/model_deletion_test.cc)
   target_include_directories(model_deletion_test PRIVATE ${SRCDIR})
   target_link_libraries(model_deletion_test PRIVATE VSM_DLL lua_static)

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -1,5 +1,8 @@
 #include <log/log.hpp>
+#include <atomic>
 #include <cassert>
+#include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <format>
 #include "model.hpp"
@@ -16,6 +19,9 @@
 
 namespace
 {
+constexpr char randomSeedSequenceKey[] = "openvsm.random_seed.sequence";
+std::atomic<std::uint64_t> nextRandomSeedSequence{1};
+
 int lua_print(lua_State *L)
 {
     int nargs = lua_gettop(L);
@@ -36,6 +42,28 @@ int lua_print(lua_State *L)
         }
     }
     return 0;
+}
+
+void seedLuaRandomGenerator(lua_State *lua)
+{
+    const auto sequence = nextRandomSeedSequence.fetch_add(1, std::memory_order_relaxed);
+    const auto timestamp = static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+    const auto address = static_cast<std::uint64_t>(reinterpret_cast<std::uintptr_t>(lua));
+    const auto firstSeed = static_cast<lua_Integer>(timestamp ^ (address + 0x9e3779b97f4a7c15ULL));
+    const auto secondSeed = static_cast<lua_Integer>(sequence);
+
+    lua_getglobal(lua, "math");
+    lua_getfield(lua, -1, "randomseed");
+    lua_pushinteger(lua, firstSeed);
+    lua_pushinteger(lua, secondSeed);
+    if (lua_pcall(lua, 2, 0, 0) != LUA_OK)
+    {
+        LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(lua, -1));
+        return;
+    }
+
+    lua_pushinteger(lua, secondSeed);
+    lua_setfield(lua, LUA_REGISTRYINDEX, randomSeedSequenceKey);
 }
 } // namespace
 
@@ -60,21 +88,7 @@ VirtualDevice::VirtualDevice()
     luaL_openlibs(luactx_);
     lua_pushcfunction(luactx_, lua_print);
     lua_setglobal(luactx_, "print");
-    lua_getglobal(luactx_, "os");
-    lua_getfield(luactx_, -1, "time");
-    if (lua_pcall(luactx_, 0, 1, 0) != LUA_OK)
-    {
-        LOG_DEBUG("Error calling os.time: {}\n", lua_tostring(luactx_, -1));
-    }
-
-    lua_getglobal(luactx_, "math");
-    lua_getfield(luactx_, -1, "randomseed");
-    lua_pushvalue(luactx_, -3);
-
-    if (lua_pcall(luactx_, 1, 0, 0) != LUA_OK)
-    {
-        LOG_DEBUG("Error calling math.randomseed: {}\n", lua_tostring(luactx_, -1));
-    }
+    seedLuaRandomGenerator(luactx_);
     lua_settop(luactx_, stackGuard.top());
     LOG_DEBUG("Lua context created\n");
 }

--- a/model/tests/random_seed_test.cc
+++ b/model/tests/random_seed_test.cc
@@ -1,0 +1,34 @@
+#include "model.hpp"
+
+#include <set>
+
+namespace
+{
+constexpr char randomSeedSequenceKey[] = "openvsm.random_seed.sequence";
+}
+
+int main()
+{
+    std::set<lua_Integer> observedSequences;
+    constexpr int deviceCount = 128;
+
+    for (int index = 0; index < deviceCount; ++index)
+    {
+        DeviceSimulator::VirtualDevice device;
+        auto *lua = device.getLuaContext();
+        lua_getfield(lua, LUA_REGISTRYINDEX, randomSeedSequenceKey);
+        if (!lua_isinteger(lua, -1))
+        {
+            return 1;
+        }
+
+        const auto sequence = lua_tointeger(lua, -1);
+        lua_pop(lua, 1);
+        if (!observedSequences.insert(sequence).second)
+        {
+            return 2;
+        }
+    }
+
+    return observedSequences.size() == deviceCount ? 0 : 3;
+}


### PR DESCRIPTION
## What changed

- replace second-resolution `os.time()` seeding with a two-part Lua 5.4 seed
- combine a high-resolution monotonic timestamp and Lua-state address for the first seed
- use an atomic process-wide sequence for guaranteed per-device distinction in the second seed
- record the private sequence in the Lua registry for deterministic regression coverage
- add a test that rapidly constructs 128 devices and verifies every sequence is unique

## Why

Components created during the same second previously received the same `math.randomseed(os.time())` value and therefore repeated the same Lua random stream.

## Validation

- Win32 Release `random_seed_test` target builds
- `random_seed` passes under CTest
- all 128 immediately-created device states receive distinct sequences