### PR TITLE
Package Lua examples with the installer

### DIFF
--- a/examples/NAND/device.txt
+++ b/examples/NAND/device.txt
@@ -29,6 +29,6 @@ NAME=LUA_NAND
 
 {MODDLL=openvsm.DLL}
 {
-LUA=device.lua}
+LUA=NAND/nand.lua}
 
 {PACKAGE=DIL8}

--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -34,3 +34,7 @@ Setup detects Proteus 7 or 8 Professional from the registry and displays the
 resulting Models directory for confirmation. If registry detection fails, the
 user must select an existing Proteus Models directory; Setup does not silently
 install model DLLs into the OpenVSM application directory.
+
+Lua examples are copied below `{app}\LuaScripts` with their repository
+subdirectories preserved. Existing or user-modified example files are never
+overwritten or removed during uninstall.

--- a/externals/installer/openvsm.iss
+++ b/externals/installer/openvsm.iss
@@ -36,6 +36,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 Source: "{#OpenVsmDllPath}"; DestDir: "{code:GetProteusModelsDir}"; DestName: "openvsm.dll"; Flags: ignoreversion
+Source: "..\..\examples\*.lua"; DestDir: "{app}\LuaScripts"; Flags: ignoreversion recursesubdirs createallsubdirs onlyifdoesntexist uninsneveruninstall
 
 [Icons]
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"


### PR DESCRIPTION
## What changed

- package all Lua examples below the installed `LuaScripts` directory
- preserve the repository subdirectory layout (`NAND`, `graphics`, and `mcu`)
- never overwrite existing examples and never remove them during uninstall
- correct the NAND device metadata to load the actual `NAND/nand.lua` script
- document the installed example behavior

## Why

The installer previously created an empty script directory, so a successful installation did not provide even one runnable Lua model. The NAND metadata also referenced nonexistent `device.lua`.

## Validation

The Release installer compiled successfully with Inno Setup 6.2.2 and its payload log includes:

- `graphics/display.lua`
- `mcu/mcu.lua`
- `NAND/nand.lua`