### PR TITLE
Add optional release code signing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,40 @@ endif()
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/model/VERSION.txt" OPENVSM_VERSION)
 option(DLL_WITH_INSTALLER "Enable the Inno Setup installer target" OFF)
 option(BUILD_DOCS "Build the Doxygen developer reference" OFF)
+set(OPENVSM_SIGN_CERTIFICATE_SHA1 "" CACHE STRING "SHA-1 thumbprint of the release-signing certificate")
+set(OPENVSM_SIGN_TIMESTAMP_URL "https://timestamp.digicert.com" CACHE STRING "RFC 3161 timestamp service")
+set(OPENVSM_SIGNTOOL "" CACHE FILEPATH "Path to signtool.exe")
+
+if(OPENVSM_SIGN_CERTIFICATE_SHA1)
+  string(REPLACE " " "" OPENVSM_SIGN_CERTIFICATE_SHA1 "${OPENVSM_SIGN_CERTIFICATE_SHA1}")
+
+  if(NOT OPENVSM_SIGNTOOL)
+    if(WIN32)
+      file(GLOB OPENVSM_SIGNTOOL_CANDIDATES
+        "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/bin/*/x64/signtool.exe"
+        "$ENV{ProgramFiles\(x86\)}/Windows Kits/10/bin/*/x86/signtool.exe"
+      )
+      if(OPENVSM_SIGNTOOL_CANDIDATES)
+        list(SORT OPENVSM_SIGNTOOL_CANDIDATES COMPARE NATURAL ORDER DESCENDING)
+        list(GET OPENVSM_SIGNTOOL_CANDIDATES 0 OPENVSM_SIGNTOOL)
+      endif()
+    else()
+      find_program(OPENVSM_SIGNTOOL NAMES signtool.exe signtool)
+    endif()
+  endif()
+
+  if(NOT EXISTS "${OPENVSM_SIGNTOOL}")
+    message(FATAL_ERROR "Code signing was requested, but signtool.exe was not found. Set OPENVSM_SIGNTOOL.")
+  endif()
+
+  set(OPENVSM_SIGN_ARGS
+    sign
+    /sha1 "${OPENVSM_SIGN_CERTIFICATE_SHA1}"
+    /fd SHA256
+    /tr "${OPENVSM_SIGN_TIMESTAMP_URL}"
+    /td SHA256
+  )
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")  
   message(INFO "MSVC found, continue...")
@@ -59,6 +93,13 @@ if(DLL_WITH_INSTALLER)
   find_program(INNO_SETUP_COMPILER NAMES ISCC.exe ISCC REQUIRED)
   set(INNO_SETUP_SCRIPT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/installer/openvsm.iss")
   set(INNO_SETUP_OUTPUT_DIR "${CMAKE_BINARY_DIR}/installer")
+  set(OPENVSM_INSTALLER_PATH "${INNO_SETUP_OUTPUT_DIR}/openvsm-${OPENVSM_VERSION}-setup.exe")
+  set(OPENVSM_INSTALLER_SIGN_COMMAND)
+  if(OPENVSM_SIGN_CERTIFICATE_SHA1)
+    list(APPEND OPENVSM_INSTALLER_SIGN_COMMAND
+      COMMAND "${OPENVSM_SIGNTOOL}" ${OPENVSM_SIGN_ARGS} "${OPENVSM_INSTALLER_PATH}"
+    )
+  endif()
   add_custom_target(BuildInstaller
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${INNO_SETUP_OUTPUT_DIR}"
                     COMMAND "${INNO_SETUP_COMPILER}"
@@ -66,6 +107,7 @@ if(DLL_WITH_INSTALLER)
                             "/DOpenVsmDllPath=$<TARGET_FILE:VSM_DLL>"
                             "/DOpenVsmOutputDir=${INNO_SETUP_OUTPUT_DIR}"
                             "${INNO_SETUP_SCRIPT_PATH}"
+                    ${OPENVSM_INSTALLER_SIGN_COMMAND}
                     COMMENT "Building the OpenVSM installer"
                     VERBATIM
   )

--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -12,3 +12,16 @@ cmake --build .build/installer --config Release --target BuildInstaller
 The installer is written below `.build/installer/installer`. A normal OpenVSM
 configure/build leaves `DLL_WITH_INSTALLER` disabled and does not require Inno
 Setup.
+
+Release builds can sign both `openvsm.dll` and the generated installer with a
+certificate from the Windows certificate store:
+
+```powershell
+cmake -S . -B .build/signed -A Win32 -DDLL_WITH_INSTALLER=ON `
+  -DOPENVSM_SIGN_CERTIFICATE_SHA1=<certificate-thumbprint>
+cmake --build .build/signed --config Release --target BuildInstaller
+```
+
+Set `OPENVSM_SIGNTOOL` when `signtool.exe` is not on `PATH` or in the standard
+Windows SDK directory. `OPENVSM_SIGN_TIMESTAMP_URL` selects the RFC 3161
+timestamp service and defaults to DigiCert.

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -73,6 +73,14 @@ target_compile_options(VSM_DLL PRIVATE
   $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/EHsc>
 )
 
+if(OPENVSM_SIGN_CERTIFICATE_SHA1)
+  add_custom_command(TARGET VSM_DLL POST_BUILD
+    COMMAND "${OPENVSM_SIGNTOOL}" ${OPENVSM_SIGN_ARGS} "$<TARGET_FILE:VSM_DLL>"
+    COMMENT "Signing openvsm.dll"
+    VERBATIM
+  )
+endif()
+
 set_target_properties(VSM_DLL PROPERTIES PREFIX "")
 set_target_properties(VSM_DLL PROPERTIES OUTPUT_NAME "openvsm")
 


### PR DESCRIPTION
## What changed

- add opt-in Authenticode signing for `openvsm.dll`
- sign the generated setup executable after Inno Setup completes
- select a certificate by Windows certificate-store SHA-1 thumbprint
- use SHA-256 file digests and RFC 3161 timestamping
- locate the Windows SDK SignTool automatically or accept an explicit path
- document the signed release command

## Why

Release artifacts were always unsigned, producing an unknown-publisher experience and preventing provenance verification. The build now supports signing without storing a certificate or password in the repository.

## Validation

- a normal unsigned Win32 Release installer still builds successfully
- a signing-enabled configure locates the Windows SDK x86 SignTool
- generated Debug/Release DLL and installer build commands contain the selected thumbprint, SHA-256 digest options, and timestamp URL

An actual trusted signature cannot be produced until a release certificate is available in the Windows certificate store.