### PR TITLE
Exercise simulation callbacks after model setup

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -130,7 +130,10 @@ if(BUILD_TESTS)
   add_executable(simulation_stack_test tests/simulation_stack_test.cc)
   target_include_directories(simulation_stack_test PRIVATE ${SRCDIR})
   target_link_libraries(simulation_stack_test PRIVATE VSM_DLL lua_static)
-  add_test(NAME simulation_stack COMMAND simulation_stack_test)
+  add_test(
+    NAME simulation_stack
+    COMMAND simulation_stack_test "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/empty_device.lua"
+  )
 
   add_executable(random_seed_test tests/random_seed_test.cc)
   target_include_directories(random_seed_test PRIVATE ${SRCDIR})

--- a/model/tests/fixtures/empty_device.lua
+++ b/model/tests/fixtures/empty_device.lua
@@ -1,0 +1,1 @@
+device_pins = {}

--- a/model/tests/simulation_stack_test.cc
+++ b/model/tests/simulation_stack_test.cc
@@ -1,16 +1,169 @@
-#include <string>
-#include <vector>
 #include "model.hpp"
-#include <lua.hpp>
+
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <utility>
 
 namespace
 {
+class FakeInstance final : public IINSTANCE
+{
+  public:
+    FakeInstance(std::string instanceId, std::string modelScript)
+        : instanceId_(std::move(instanceId)), modelScript_(std::move(modelScript))
+    {
+    }
+
+    CHAR *id() override
+    {
+        return &instanceId_[0];
+    }
+    CHAR *value() override
+    {
+        return nullptr;
+    }
+    CHAR *getstrval(CHAR *name, CHAR *defaultValue = nullptr) override
+    {
+        return std::strcmp(name, "LUA") == 0 ? &modelScript_[0] : defaultValue;
+    }
+    void getnumval(DOUBLE *result, CHAR *, DOUBLE defaultValue = 0) override
+    {
+        *result = defaultValue;
+    }
+    BOOL getboolval(CHAR *, BOOL defaultValue = FALSE) override
+    {
+        return defaultValue;
+    }
+    DWORD gethexval(CHAR *, DWORD defaultValue = 0) override
+    {
+        return defaultValue;
+    }
+    LONG getinitval(CHAR *, LONG defaultValue = 0) override
+    {
+        return defaultValue;
+    }
+    RELTIME getdelay(CHAR *, RELTIME defaultValue = 0) override
+    {
+        return defaultValue;
+    }
+    IACTIVEMODEL *getactivemodel() override
+    {
+        return nullptr;
+    }
+    IINSTANCE *getinterfacemodel() override
+    {
+        return nullptr;
+    }
+    BOOL getmoddata(BYTE **data, DWORD *size) override
+    {
+        *data = nullptr;
+        *size = 0;
+        return FALSE;
+    }
+    SPICENODE getspicenode(CHAR *, BOOL) override
+    {
+        return 0;
+    }
+    IDSIMPIN *getdsimpin(CHAR *, BOOL) override
+    {
+        return nullptr;
+    }
+    void log(CHAR *, ...) override
+    {
+    }
+    void warning(CHAR *, ...) override
+    {
+    }
+    void error(CHAR *, ...) override
+    {
+    }
+    void fatal(CHAR *, ...) override
+    {
+    }
+    BOOL message(CHAR *, ...) override
+    {
+        return TRUE;
+    }
+    IPOPUP *createpopup(CREATEPOPUPSTRUCT *) override
+    {
+        return nullptr;
+    }
+    void deletepopup(POPUPID) override
+    {
+    }
+    BOOL setvdmhlr(ICPU *) override
+    {
+        return TRUE;
+    }
+    BOOL loadmemory(CHAR *, VOID *, UINT, UINT = 0, UINT = 0) override
+    {
+        return FALSE;
+    }
+    IBUSPIN *getbuspin(CHAR *, UINT, UINT, BOOL) override
+    {
+        return nullptr;
+    }
+    IBUSPIN *getbuspin(CHAR *, IDSIMPIN **, UINT) override
+    {
+        return nullptr;
+    }
+
+  private:
+    std::string instanceId_;
+    std::string modelScript_;
+};
+
+class FakeDsim final : public IDSIMCKT
+{
+  public:
+    void sysvar(DOUBLE *result, DSIMVARS variable) override
+    {
+        if (variable == DSIMTIMENOW)
+        {
+            ABSTIME time = 0;
+            std::memcpy(result, &time, sizeof(time));
+        }
+    }
+    EVENT *setcallback(ABSTIME, IDSIMMODEL *, EVENTID) override
+    {
+        return nullptr;
+    }
+    BOOL cancelcallback(EVENT *, IDSIMMODEL *) override
+    {
+        return FALSE;
+    }
+    void setbreak(ABSTIME) override
+    {
+    }
+    void suspend(IINSTANCE *, CHAR *) override
+    {
+    }
+    EVENT *setcallbackex(ABSTIME, IDSIMMODEL *, CALLBACKHANDLERFN, EVENTID) override
+    {
+        return nullptr;
+    }
+    DSIMNODE newnode(CHAR *, CHAR *) override
+    {
+        return nullptr;
+    }
+    IDSIMPIN *newpin(IINSTANCE *, DSIMNODE, CHAR *, DWORD) override
+    {
+        return nullptr;
+    }
+    EVENT *setclockcallback(ABSTIME, RELTIME, IDSIMMODEL *, CALLBACKHANDLERFN, EVENTID) override
+    {
+        return nullptr;
+    }
+};
+
 bool runLua(lua_State *luaContext, const char *script)
 {
     if (luaL_dostring(luaContext, script) == LUA_OK)
     {
         return true;
     }
+    std::cerr << lua_tostring(luaContext, -1) << '\n';
     lua_pop(luaContext, 1);
     return false;
 }
@@ -29,22 +182,25 @@ bool stackIsStable(DeviceSimulator::VirtualDevice &device, int ticks)
     }
     return true;
 }
+
+void setupDevice(DeviceSimulator::VirtualDevice &device, FakeInstance &instance, FakeDsim &dsim)
+{
+    device.setup(&instance, &dsim);
+}
 } // namespace
 
-int main()
+int main(int argumentCount, char **arguments)
 {
+    if (argumentCount != 2)
+    {
+        std::cerr << "Expected the empty device fixture path\n";
+        return 1;
+    }
+    const std::string scriptPath = arguments[1];
+
     {
         DeviceSimulator::VirtualDevice device;
         if (!stackIsStable(device, 128))
-        {
-            return 1;
-        }
-    }
-
-    {
-        DeviceSimulator::VirtualDevice device;
-        lua_State *luaContext = device.getLuaContext();
-        if (!runLua(luaContext, "device_simulate = 42") || !stackIsStable(device, 128))
         {
             return 2;
         }
@@ -52,38 +208,56 @@ int main()
 
     {
         DeviceSimulator::VirtualDevice device;
+        FakeInstance instance{"non-function", scriptPath};
+        FakeDsim dsim;
+        setupDevice(device, instance, dsim);
+        lua_State *luaContext = device.getLuaContext();
+        if (!runLua(luaContext, "device_simulate = 42") || !stackIsStable(device, 128))
+        {
+            return 3;
+        }
+    }
+
+    {
+        DeviceSimulator::VirtualDevice device;
+        FakeInstance instance{"successful-callback", scriptPath};
+        FakeDsim dsim;
+        setupDevice(device, instance, dsim);
         lua_State *luaContext = device.getLuaContext();
         if (!runLua(luaContext,
                     "simulation_calls = 0; function device_simulate() simulation_calls = simulation_calls + 1 end") ||
             !stackIsStable(device, 128))
         {
-            return 3;
+            return 4;
         }
         lua_getglobal(luaContext, "simulation_calls");
         const bool calledEveryTick = lua_tointeger(luaContext, -1) == 128;
         lua_pop(luaContext, 1);
         if (!calledEveryTick)
         {
-            return 4;
+            return 5;
         }
     }
 
     {
         DeviceSimulator::VirtualDevice device;
+        FakeInstance instance{"failing-callback", scriptPath};
+        FakeDsim dsim;
+        setupDevice(device, instance, dsim);
         lua_State *luaContext = device.getLuaContext();
         if (!runLua(luaContext,
                     "simulation_calls = 0; function device_simulate() simulation_calls = simulation_calls + 1; "
                     "error('tick failure') end") ||
             !stackIsStable(device, 128))
         {
-            return 5;
+            return 6;
         }
         lua_getglobal(luaContext, "simulation_calls");
         const bool disabledAfterFailure = lua_tointeger(luaContext, -1) == 1;
         lua_pop(luaContext, 1);
         if (!disabledAfterFailure)
         {
-            return 6;
+            return 7;
         }
     }
 


### PR DESCRIPTION
## What changed

- replace the obsolete simulation-stack fixture with a minimal fake Proteus instance and DSim context
- load an empty real model script through `VirtualDevice::setup`
- keep the pre-setup stack-stability check
- verify non-function callbacks are ignored without stack growth
- verify successful callbacks run for all 128 ticks
- verify a failing callback runs once and is then disabled

## Why

The old test injected `device_simulate` into a newly constructed model and expected it to run before `setup()`. Production correctly keeps `modelReady_` false until a model script and host interfaces have been initialized, so the test failed without exercising the intended callback path.

## Validation

- clean Win32 Release `simulation_stack_test` target builds
- `simulation_stack` passes under CTest