### PR TITLE
Detect the shared Proteus Models directory

### DIFF
--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -30,9 +30,11 @@ Set `OPENVSM_SIGNTOOL` when `signtool.exe` is not on `PATH` or in the standard
 Windows SDK directory. `OPENVSM_SIGN_TIMESTAMP_URL` selects the RFC 3161
 timestamp service and defaults to DigiCert.
 
-Setup detects Proteus 7 or 8 Professional from the registry and displays the
-resulting Models directory for confirmation. If registry detection fails, the
-user must select an existing Proteus Models directory; Setup does not silently
+Setup first checks the shared Proteus 8 Models directory below
+`{commonappdata}\Labcenter Electronics\Proteus 8 Professional\MODELS`, then
+falls back to detecting Proteus 7 or 8 Professional from the registry. The
+resulting directory is displayed for confirmation. If detection fails, the user
+must select an existing Proteus Models directory; Setup does not silently
 install model DLLs into the OpenVSM application directory.
 
 Lua examples are copied below `{app}\LuaScripts` with their repository

--- a/externals/installer/openvsm.iss
+++ b/externals/installer/openvsm.iss
@@ -139,6 +139,27 @@ begin
   end;
 end;
 
+function GetDetectedProteusModelsDir(): string;
+var
+  InstallDir: string;
+  SharedModelsDir: string;
+begin
+  SharedModelsDir := ExpandConstant(
+    '{commonappdata}\Labcenter Electronics\Proteus 8 Professional\MODELS');
+  if DirExists(SharedModelsDir) then
+  begin
+    Result := SharedModelsDir;
+    exit;
+  end;
+
+  Result := '';
+  InstallDir := GetDetectedProteusInstallDir();
+  if InstallDir <> '' then
+  begin
+    Result := AddBackslash(InstallDir) + 'Models';
+  end;
+end;
+
 function GetProteusModelsDir(Value: string): string;
 begin
   Result := ProteusModelsPage.Values[0];
@@ -154,7 +175,7 @@ end;
 
 procedure InitializeWizard();
 var
-  InstallDir: string;
+  ModelsDir: string;
 begin
   ProteusModelsPage := CreateInputDirPage(
     wpSelectDir,
@@ -165,10 +186,10 @@ begin
     '');
   ProteusModelsPage.Add('');
 
-  InstallDir := GetDetectedProteusInstallDir();
-  if InstallDir <> '' then
+  ModelsDir := GetDetectedProteusModelsDir();
+  if ModelsDir <> '' then
   begin
-    ProteusModelsPage.Values[0] := AddBackslash(InstallDir) + 'Models';
+    ProteusModelsPage.Values[0] := ModelsDir;
   end;
 end;
 


### PR DESCRIPTION
## What changed

- prefer `{commonappdata}\Labcenter Electronics\Proteus 8 Professional\MODELS` when selecting the installer destination
- retain registry-derived Proteus installation folders as a fallback for older layouts
- document the shared ProgramData location

## Root cause

Proteus 8 stores shared model DLLs under `C:\ProgramData`, while the installer previously appended `Models` to the executable installation directory obtained from the registry.

## Validation

- confirmed `C:\ProgramData\Labcenter Electronics\Proteus 8 Professional\MODELS` exists on the development machine
- rebuilt the OpenVSM 0.7 installer with Inno Setup successfully
- confirmed the existing manual-selection and directory-validation paths remain intact