### PR TITLE
Add a portable CHIP-8 core

### DIFF
--- a/examples/chip8/README.md
+++ b/examples/chip8/README.md
@@ -46,6 +46,36 @@ Execution is deterministic when `random_byte` is injected. Timers are separated
 from instruction execution so a Proteus callback, an ImGui event loop, or a
 headless test can drive the same core at an exact 60 Hz.
 
+## Proteus device stub
+
+`device.txt` follows the same Proteus library-description structure as the NAND
+example and loads `chip8/device.lua` through `openvsm.DLL`. The first version is
+a self-contained virtual console with no electrical pins. Its DIL8 package is a
+temporary metadata placeholder inherited from the NAND stub; the component is
+not yet intended for PCB placement.
+
+The active schematic face is a compact horizontal console:
+
+```text
++--------------------------------------------------+
+| CHIP-8                                  HOST STUB |
+| +----------------------------+   [1] [2] [3] [C] |
+| |                            |   [4] [5] [6] [D] |
+| |           NO ROM           |   [7] [8] [9] [E] |
+| |                            |   [A] [0] [B] [F] |
+| +----------------------------+                   |
+| STOP  PC:0200  60 Hz                             |
++--------------------------------------------------+
+```
+
+The 192-by-96 display area preserves the CHIP-8 2:1 aspect ratio and gives every
+64-by-32 framebuffer pixel an exact 3-by-3 drawing cell. Pixels will be lime on
+black. The status strip is reserved for run state, program counter, and timer
+rate. The canonical hexadecimal keypad is already drawn and responds visually
+to mouse clicks, but it is not connected to the VM until the host adapter is
+implemented. `NO ROM` and `HOST STUB` make that unfinished state explicit when
+the component is placed in Proteus.
+
 ## Planned host adapters
 
 - OpenVSM: map `device_graphics_plot` to the framebuffer, translate actuation

--- a/examples/chip8/README.md
+++ b/examples/chip8/README.md
@@ -1,0 +1,56 @@
+# Portable CHIP-8 core
+
+This example starts with the emulator core rather than a Proteus-specific
+component. `core.lua` implements the classic 4 KiB, 64-by-32 CHIP-8 machine and
+depends only on Lua 5.4. ROMs are deliberately not included.
+
+The core accepts a display object with two operations:
+
+```lua
+display:clear()
+local collision = display:xor_pixel(x, y)
+```
+
+`framebuffer.lua` is the reference headless implementation. It owns the pixels,
+tracks dirty state and revisions, and exposes snapshots for renderers. A future
+OpenVSM adapter can draw this framebuffer through the existing `graphics` API;
+an ImGui adapter can consume the same pixels without changing the VM.
+
+## Core API
+
+```lua
+local Chip8 = dofile("core.lua")
+local Framebuffer = dofile("framebuffer.lua")
+
+local display = Framebuffer.new(Chip8.DISPLAY_WIDTH, Chip8.DISPLAY_HEIGHT)
+local vm = Chip8.new({
+    display = display,
+    profile = "modern",
+    random_byte = function()
+        return math.random(0, 255)
+    end
+})
+
+vm:load_rom(rom_bytes)
+vm:run(instructions_per_slice)
+vm:tick_timers(1) -- call at 60 Hz
+vm:set_key(0xa, true)
+```
+
+The default `modern` profile shifts `VX` and leaves `I` unchanged after
+`FX55`/`FX65`. The `original` profile shifts `VY` and increments `I`. Individual
+quirks can be overridden through `quirks`: `clip_sprites`, `jump_uses_vx`,
+`load_store_increment_i`, and `shift_uses_vy`.
+
+Execution is deterministic when `random_byte` is injected. Timers are separated
+from instruction execution so a Proteus callback, an ImGui event loop, or a
+headless test can drive the same core at an exact 60 Hz.
+
+## Planned host adapters
+
+- OpenVSM: map `device_graphics_plot` to the framebuffer, translate actuation
+  into the 16 CHIP-8 keys, call `graphics.repaint` only when dirty, and schedule
+  CPU/timer slices with simulation time.
+- ImGui: render the same 64-by-32 snapshot as a scaled texture or draw list and
+  map desktop keys to `set_key`.
+- Headless: use `framebuffer.lua`, as the native CTest harness does today.

--- a/examples/chip8/core.lua
+++ b/examples/chip8/core.lua
@@ -1,0 +1,416 @@
+local Chip8 = {}
+Chip8.__index = Chip8
+
+Chip8.MEMORY_SIZE = 4096
+Chip8.PROGRAM_ADDRESS = 0x200
+Chip8.FONT_ADDRESS = 0x050
+Chip8.DISPLAY_WIDTH = 64
+Chip8.DISPLAY_HEIGHT = 32
+Chip8.STACK_DEPTH = 16
+
+local font = {
+    0xf0, 0x90, 0x90, 0x90, 0xf0,
+    0x20, 0x60, 0x20, 0x20, 0x70,
+    0xf0, 0x10, 0xf0, 0x80, 0xf0,
+    0xf0, 0x10, 0xf0, 0x10, 0xf0,
+    0x90, 0x90, 0xf0, 0x10, 0x10,
+    0xf0, 0x80, 0xf0, 0x10, 0xf0,
+    0xf0, 0x80, 0xf0, 0x90, 0xf0,
+    0xf0, 0x10, 0x20, 0x40, 0x40,
+    0xf0, 0x90, 0xf0, 0x90, 0xf0,
+    0xf0, 0x90, 0xf0, 0x10, 0xf0,
+    0xf0, 0x90, 0xf0, 0x90, 0x90,
+    0xe0, 0x90, 0xe0, 0x90, 0xe0,
+    0xf0, 0x80, 0x80, 0x80, 0xf0,
+    0xe0, 0x90, 0x90, 0x90, 0xe0,
+    0xf0, 0x80, 0xf0, 0x80, 0xf0,
+    0xf0, 0x80, 0xf0, 0x80, 0x80
+}
+
+local known_quirks = {
+    clip_sprites = true,
+    jump_uses_vx = true,
+    load_store_increment_i = true,
+    shift_uses_vy = true
+}
+
+local function check_integer(name, value, minimum, maximum)
+    if math.type(value) ~= "integer" or value < minimum or value > maximum then
+        error(string.format("%s must be an integer from %d to %d", name, minimum, maximum), 3)
+    end
+    return value
+end
+
+local function copy_quirks(options)
+    local profile = options.profile or "modern"
+    if profile ~= "modern" and profile ~= "original" then
+        error("CHIP-8 profile must be 'modern' or 'original'", 3)
+    end
+
+    local quirks = {
+        clip_sprites = false,
+        jump_uses_vx = false,
+        load_store_increment_i = profile == "original",
+        shift_uses_vy = profile == "original"
+    }
+
+    for name, enabled in pairs(options.quirks or {}) do
+        if not known_quirks[name] then
+            error("unknown CHIP-8 quirk: " .. tostring(name), 3)
+        end
+        quirks[name] = not not enabled
+    end
+    return quirks
+end
+
+local function check_display(display)
+    if display == nil or type(display.clear) ~= "function" or type(display.xor_pixel) ~= "function" then
+        error("CHIP-8 display must provide clear() and xor_pixel(x, y)", 3)
+    end
+end
+
+local function invalid_opcode(vm, opcode)
+    error(string.format("unsupported CHIP-8 opcode 0x%04X at 0x%03X", opcode, vm.current_address), 0)
+end
+
+local function read_memory(vm, address)
+    if math.type(address) ~= "integer" or address < 0 or address >= Chip8.MEMORY_SIZE then
+        error(string.format("CHIP-8 memory read outside 0x000..0xFFF: 0x%X", address), 0)
+    end
+    return vm.memory[address]
+end
+
+local function write_memory(vm, address, value)
+    if math.type(address) ~= "integer" or address < 0 or address >= Chip8.MEMORY_SIZE then
+        error(string.format("CHIP-8 memory write outside 0x000..0xFFF: 0x%X", address), 0)
+    end
+    vm.memory[address] = value & 0xff
+end
+
+local function first_pressed_key(vm)
+    for key = 0, 15 do
+        if vm.keys[key] then
+            return key
+        end
+    end
+    return nil
+end
+
+local function draw_sprite(vm, x_register, y_register, rows)
+    local origin_x = vm.v[x_register]
+    local origin_y = vm.v[y_register]
+    local collision = false
+
+    for row = 0, rows - 1 do
+        local sprite = read_memory(vm, vm.i + row)
+        for bit = 0, 7 do
+            if (sprite & (0x80 >> bit)) ~= 0 then
+                local x = origin_x + bit
+                local y = origin_y + row
+                if vm.quirks.clip_sprites then
+                    if x < Chip8.DISPLAY_WIDTH and y < Chip8.DISPLAY_HEIGHT then
+                        collision = vm.display:xor_pixel(x, y) or collision
+                    end
+                else
+                    x = x % Chip8.DISPLAY_WIDTH
+                    y = y % Chip8.DISPLAY_HEIGHT
+                    collision = vm.display:xor_pixel(x, y) or collision
+                end
+            end
+        end
+    end
+
+    vm.v[0xf] = collision and 1 or 0
+end
+
+function Chip8.new(options)
+    options = options or {}
+    check_display(options.display)
+
+    local vm = setmetatable({
+        display = options.display,
+        quirks = copy_quirks(options),
+        random_byte = options.random_byte or function()
+            return math.random(0, 255)
+        end,
+        memory = {},
+        v = {},
+        stack = {},
+        keys = {}
+    }, Chip8)
+
+    if type(vm.random_byte) ~= "function" then
+        error("CHIP-8 random_byte must be a function", 2)
+    end
+
+    vm:reset()
+    return vm
+end
+
+function Chip8:reset()
+    for address = 0, Chip8.MEMORY_SIZE - 1 do
+        self.memory[address] = 0
+    end
+    for register = 0, 15 do
+        self.v[register] = 0
+        self.keys[register] = false
+    end
+    for level = 1, Chip8.STACK_DEPTH do
+        self.stack[level] = 0
+    end
+    for offset, value in ipairs(font) do
+        self.memory[Chip8.FONT_ADDRESS + offset - 1] = value
+    end
+
+    self.i = 0
+    self.pc = Chip8.PROGRAM_ADDRESS
+    self.sp = 0
+    self.delay_timer = 0
+    self.sound_timer = 0
+    self.cycles = 0
+    self.last_opcode = nil
+    self.current_address = self.pc
+    self.display:clear()
+end
+
+function Chip8:load_rom(rom, address)
+    address = address or Chip8.PROGRAM_ADDRESS
+    check_integer("ROM address", address, 0, Chip8.MEMORY_SIZE - 1)
+
+    local bytes = {}
+    if type(rom) == "string" then
+        for index = 1, #rom do
+            bytes[index] = string.byte(rom, index)
+        end
+    elseif type(rom) == "table" then
+        for index = 1, #rom do
+            bytes[index] = check_integer("ROM byte", rom[index], 0, 255)
+        end
+    else
+        error("CHIP-8 ROM must be a byte string or array", 2)
+    end
+
+    if #bytes > Chip8.MEMORY_SIZE - address then
+        error("CHIP-8 ROM does not fit in memory", 2)
+    end
+
+    self:reset()
+    for offset, value in ipairs(bytes) do
+        self.memory[address + offset - 1] = value
+    end
+    self.pc = address
+    return #bytes
+end
+
+function Chip8:peek(address)
+    check_integer("memory address", address, 0, Chip8.MEMORY_SIZE - 1)
+    return self.memory[address]
+end
+
+function Chip8:poke(address, value)
+    check_integer("memory address", address, 0, Chip8.MEMORY_SIZE - 1)
+    check_integer("memory value", value, 0, 255)
+    self.memory[address] = value
+end
+
+function Chip8:set_key(key, pressed)
+    check_integer("key", key, 0, 15)
+    self.keys[key] = not not pressed
+end
+
+function Chip8:tick_timers(ticks)
+    ticks = ticks or 1
+    check_integer("timer ticks", ticks, 0, 0x7fffffff)
+
+    local was_sounding = self.sound_timer > 0
+    self.delay_timer = math.max(0, self.delay_timer - ticks)
+    self.sound_timer = math.max(0, self.sound_timer - ticks)
+    return was_sounding, self.sound_timer > 0
+end
+
+function Chip8:snapshot()
+    local registers = {}
+    for register = 0, 15 do
+        registers[register] = self.v[register]
+    end
+    return {
+        cycles = self.cycles,
+        delay_timer = self.delay_timer,
+        i = self.i,
+        pc = self.pc,
+        registers = registers,
+        sound_timer = self.sound_timer,
+        sp = self.sp
+    }
+end
+
+function Chip8:run(cycles)
+    check_integer("cycles", cycles, 0, 0x7fffffff)
+    for _ = 1, cycles do
+        self:step()
+    end
+end
+
+function Chip8:step()
+    if self.pc < 0 or self.pc + 1 >= Chip8.MEMORY_SIZE then
+        error(string.format("CHIP-8 instruction fetch outside memory at 0x%X", self.pc), 0)
+    end
+
+    local instruction_address = self.pc
+    local opcode = (read_memory(self, self.pc) << 8) | read_memory(self, self.pc + 1)
+    self.pc = self.pc + 2
+    self.current_address = instruction_address
+    self.last_opcode = opcode
+
+    local group = opcode & 0xf000
+    local x = (opcode >> 8) & 0xf
+    local y = (opcode >> 4) & 0xf
+    local n = opcode & 0xf
+    local byte = opcode & 0xff
+    local address = opcode & 0xfff
+
+    if opcode == 0x00e0 then
+        self.display:clear()
+    elseif opcode == 0x00ee then
+        if self.sp == 0 then
+            error("CHIP-8 stack underflow", 0)
+        end
+        self.pc = self.stack[self.sp]
+        self.stack[self.sp] = 0
+        self.sp = self.sp - 1
+    elseif group == 0x0000 then
+        -- 0NNN called an RCA 1802 routine. Modern hosts safely ignore it.
+    elseif group == 0x1000 then
+        self.pc = address
+    elseif group == 0x2000 then
+        if self.sp >= Chip8.STACK_DEPTH then
+            error("CHIP-8 stack overflow", 0)
+        end
+        self.sp = self.sp + 1
+        self.stack[self.sp] = self.pc
+        self.pc = address
+    elseif group == 0x3000 then
+        if self.v[x] == byte then
+            self.pc = self.pc + 2
+        end
+    elseif group == 0x4000 then
+        if self.v[x] ~= byte then
+            self.pc = self.pc + 2
+        end
+    elseif group == 0x5000 and n == 0 then
+        if self.v[x] == self.v[y] then
+            self.pc = self.pc + 2
+        end
+    elseif group == 0x6000 then
+        self.v[x] = byte
+    elseif group == 0x7000 then
+        self.v[x] = (self.v[x] + byte) & 0xff
+    elseif group == 0x8000 then
+        local vx = self.v[x]
+        local vy = self.v[y]
+        if n == 0x0 then
+            self.v[x] = vy
+        elseif n == 0x1 then
+            self.v[x] = vx | vy
+        elseif n == 0x2 then
+            self.v[x] = vx & vy
+        elseif n == 0x3 then
+            self.v[x] = vx ~ vy
+        elseif n == 0x4 then
+            local sum = vx + vy
+            self.v[x] = sum & 0xff
+            self.v[0xf] = sum > 0xff and 1 or 0
+        elseif n == 0x5 then
+            self.v[x] = (vx - vy) & 0xff
+            self.v[0xf] = vx >= vy and 1 or 0
+        elseif n == 0x6 then
+            local source = self.quirks.shift_uses_vy and vy or vx
+            self.v[x] = source >> 1
+            self.v[0xf] = source & 0x1
+        elseif n == 0x7 then
+            self.v[x] = (vy - vx) & 0xff
+            self.v[0xf] = vy >= vx and 1 or 0
+        elseif n == 0xe then
+            local source = self.quirks.shift_uses_vy and vy or vx
+            self.v[x] = (source << 1) & 0xff
+            self.v[0xf] = (source >> 7) & 0x1
+        else
+            invalid_opcode(self, opcode)
+        end
+    elseif group == 0x9000 and n == 0 then
+        if self.v[x] ~= self.v[y] then
+            self.pc = self.pc + 2
+        end
+    elseif group == 0xa000 then
+        self.i = address
+    elseif group == 0xb000 then
+        local base_register = self.quirks.jump_uses_vx and x or 0
+        self.pc = (address + self.v[base_register]) & 0xfff
+    elseif group == 0xc000 then
+        local random_value = self.random_byte()
+        check_integer("random byte", random_value, 0, 255)
+        self.v[x] = random_value & byte
+    elseif group == 0xd000 then
+        draw_sprite(self, x, y, n)
+    elseif group == 0xe000 then
+        local pressed = self.keys[self.v[x]] == true
+        if byte == 0x9e then
+            if pressed then
+                self.pc = self.pc + 2
+            end
+        elseif byte == 0xa1 then
+            if not pressed then
+                self.pc = self.pc + 2
+            end
+        else
+            invalid_opcode(self, opcode)
+        end
+    elseif group == 0xf000 then
+        if byte == 0x07 then
+            self.v[x] = self.delay_timer
+        elseif byte == 0x0a then
+            local key = first_pressed_key(self)
+            if key == nil then
+                self.pc = instruction_address
+            else
+                self.v[x] = key
+            end
+        elseif byte == 0x15 then
+            self.delay_timer = self.v[x]
+        elseif byte == 0x18 then
+            self.sound_timer = self.v[x]
+        elseif byte == 0x1e then
+            self.i = (self.i + self.v[x]) & 0xfff
+        elseif byte == 0x29 then
+            self.i = Chip8.FONT_ADDRESS + (self.v[x] & 0xf) * 5
+        elseif byte == 0x33 then
+            local value = self.v[x]
+            write_memory(self, self.i, value // 100)
+            write_memory(self, self.i + 1, (value // 10) % 10)
+            write_memory(self, self.i + 2, value % 10)
+        elseif byte == 0x55 then
+            for register = 0, x do
+                write_memory(self, self.i + register, self.v[register])
+            end
+            if self.quirks.load_store_increment_i then
+                self.i = (self.i + x + 1) & 0xfff
+            end
+        elseif byte == 0x65 then
+            for register = 0, x do
+                self.v[register] = read_memory(self, self.i + register)
+            end
+            if self.quirks.load_store_increment_i then
+                self.i = (self.i + x + 1) & 0xfff
+            end
+        else
+            invalid_opcode(self, opcode)
+        end
+    else
+        invalid_opcode(self, opcode)
+    end
+
+    self.cycles = self.cycles + 1
+    return opcode
+end
+
+return Chip8

--- a/examples/chip8/device.lua
+++ b/examples/chip8/device.lua
@@ -1,0 +1,115 @@
+device_pins = {}
+
+local BODY_WIDTH = 344
+local BODY_HEIGHT = 166
+local SCREEN_LEFT = 12
+local SCREEN_TOP = 30
+local SCREEN_RIGHT = 204
+local SCREEN_BOTTOM = 126
+local KEYPAD_LEFT = 220
+local KEYPAD_TOP = 30
+local KEY_SIZE = 24
+local KEY_GAP = 4
+
+local keys = {
+    {label = "1", value = 0x1},
+    {label = "2", value = 0x2},
+    {label = "3", value = 0x3},
+    {label = "C", value = 0xc},
+    {label = "4", value = 0x4},
+    {label = "5", value = 0x5},
+    {label = "6", value = 0x6},
+    {label = "D", value = 0xd},
+    {label = "7", value = 0x7},
+    {label = "8", value = 0x8},
+    {label = "9", value = 0x9},
+    {label = "E", value = 0xe},
+    {label = "A", value = 0xa},
+    {label = "0", value = 0x0},
+    {label = "B", value = 0xb},
+    {label = "F", value = 0xf}
+}
+
+local selected_key
+
+local function key_bounds(index)
+    local zero_based = index - 1
+    local column = zero_based % 4
+    local row = zero_based // 4
+    local left = KEYPAD_LEFT + column * (KEY_SIZE + KEY_GAP)
+    local top = KEYPAD_TOP + row * (KEY_SIZE + KEY_GAP)
+    return left, top, left + KEY_SIZE, top + KEY_SIZE
+end
+
+local function draw_key(index, key)
+    local left, top, right, bottom = key_bounds(index)
+    local selected = selected_key == key.value
+
+    graphics.set_pen_colour(selected and graphics.BRIGHTGREEN or graphics.WHITE)
+    graphics.set_brush_colour(selected and graphics.BRIGHTGREEN or graphics.BLACK)
+    graphics.draw_box(left, top, right, bottom)
+    graphics.set_text_colour(selected and graphics.BLACK or graphics.BRIGHTWHITE)
+    graphics.draw_text((left + right) // 2, (top + bottom) // 2, 0,
+                       graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, key.label)
+end
+
+function device_init()
+end
+
+function device_simulate()
+end
+
+function device_graphics_init()
+    graphics.set_draw_scale(96)
+    graphics.set_pen_width(1)
+    graphics.set_text_size(12)
+end
+
+function device_graphics_plot(_)
+    graphics.set_pen_colour(graphics.BRIGHTWHITE)
+    graphics.set_brush_colour(graphics.GREY)
+    graphics.draw_box(0, 0, BODY_WIDTH, BODY_HEIGHT)
+
+    graphics.set_text_colour(graphics.BRIGHTWHITE)
+    graphics.draw_text(12, 14, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE, "CHIP-8")
+    graphics.draw_text(BODY_WIDTH - 12, 14, 0, graphics.TXJ_RIGHT | graphics.TXJ_MIDDLE,
+                       "HOST STUB")
+
+    graphics.set_pen_colour(graphics.BRIGHTGREEN)
+    graphics.set_brush_colour(graphics.BLACK)
+    graphics.draw_box(SCREEN_LEFT, SCREEN_TOP, SCREEN_RIGHT, SCREEN_BOTTOM)
+    graphics.set_text_colour(graphics.BRIGHTGREEN)
+    graphics.set_text_size(14)
+    graphics.draw_text((SCREEN_LEFT + SCREEN_RIGHT) // 2,
+                       (SCREEN_TOP + SCREEN_BOTTOM) // 2, 0,
+                       graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, "NO ROM")
+
+    graphics.set_text_size(10)
+    graphics.set_text_colour(graphics.BRIGHTWHITE)
+    graphics.draw_text(SCREEN_LEFT, 144, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE,
+                       "STOP  PC:0200  60 Hz")
+
+    for index, key in ipairs(keys) do
+        draw_key(index, key)
+    end
+end
+
+function device_graphics_animate(_, _, _)
+end
+
+function device_graphics_actuate(_, x, y, flags)
+    if (flags & graphics.ACF_LEFT) == 0 then
+        return false
+    end
+
+    for index, key in ipairs(keys) do
+        local left, top, right, bottom = key_bounds(index)
+        if x >= left and x <= right and y >= top and y <= bottom then
+            selected_key = key.value
+            graphics.repaint(false)
+            return true
+        end
+    end
+
+    return false
+end

--- a/examples/chip8/device.txt
+++ b/examples/chip8/device.txt
@@ -1,0 +1,34 @@
+{*DEVICE}
+NAME=LUA_CHIP8
+
+{PREFIX=U}
+
+{*PROPDEFS}
+
+{MODDLL="VSM Model DLL",HIDDEN STRING}
+
+{LUA="LUA",STRING}
+
+{PRIMITIVE="Primitive Type",HIDDEN STRING}
+
+{PACKAGE="PCB Package",PACKAGE,0}
+
+{*INDEX}
+
+{CAT=Microprocessor ICs}
+
+{DESC=CHIP-8 virtual machine with display and hexadecimal keypad}
+
+{MFR=OpenVSM}
+
+{SUBCAT=Virtual Machines}
+
+{*COMPONENT}
+
+{PRIMITIVE=DIGITAL}
+
+{MODDLL=openvsm.DLL}
+{
+LUA=chip8/device.lua}
+
+{PACKAGE=DIL8}

--- a/examples/chip8/framebuffer.lua
+++ b/examples/chip8/framebuffer.lua
@@ -1,0 +1,91 @@
+local Framebuffer = {}
+Framebuffer.__index = Framebuffer
+
+local function check_coordinate(name, value, maximum)
+    if math.type(value) ~= "integer" or value < 0 or value >= maximum then
+        error(string.format("%s must be an integer from 0 to %d", name, maximum - 1), 3)
+    end
+end
+
+function Framebuffer.new(width, height)
+    if math.type(width) ~= "integer" or width <= 0 then
+        error("framebuffer width must be a positive integer", 2)
+    end
+    if math.type(height) ~= "integer" or height <= 0 then
+        error("framebuffer height must be a positive integer", 2)
+    end
+
+    local display = setmetatable({
+        dirty = true,
+        height = height,
+        pixels = {},
+        revision = 0,
+        width = width
+    }, Framebuffer)
+    for index = 1, width * height do
+        display.pixels[index] = 0
+    end
+    return display
+end
+
+function Framebuffer:index(x, y)
+    check_coordinate("x", x, self.width)
+    check_coordinate("y", y, self.height)
+    return y * self.width + x + 1
+end
+
+function Framebuffer:clear()
+    local changed = false
+    for index = 1, #self.pixels do
+        if self.pixels[index] ~= 0 then
+            self.pixels[index] = 0
+            changed = true
+        end
+    end
+    if changed then
+        self.dirty = true
+        self.revision = self.revision + 1
+    end
+end
+
+function Framebuffer:xor_pixel(x, y)
+    local index = self:index(x, y)
+    local collision = self.pixels[index] ~= 0
+    self.pixels[index] = collision and 0 or 1
+    self.dirty = true
+    self.revision = self.revision + 1
+    return collision
+end
+
+function Framebuffer:get_pixel(x, y)
+    return self.pixels[self:index(x, y)]
+end
+
+function Framebuffer:count_lit()
+    local count = 0
+    for _, pixel in ipairs(self.pixels) do
+        count = count + pixel
+    end
+    return count
+end
+
+function Framebuffer:snapshot()
+    local pixels = {}
+    for index, pixel in ipairs(self.pixels) do
+        pixels[index] = pixel
+    end
+    return {
+        height = self.height,
+        pixels = pixels,
+        revision = self.revision,
+        width = self.width
+    }
+end
+
+function Framebuffer:consume_dirty()
+    local was_dirty = self.dirty
+    self.dirty = false
+    return was_dirty, self.revision
+end
+
+return Framebuffer

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -234,6 +234,7 @@ if(BUILD_TESTS)
     COMMAND chip8_core_test
             "${CMAKE_SOURCE_DIR}/examples/chip8/core.lua"
             "${CMAKE_SOURCE_DIR}/examples/chip8/framebuffer.lua"
+            "${CMAKE_SOURCE_DIR}/examples/chip8/device.lua"
             "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/chip8_core_test.lua"
   )
 

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -223,6 +223,20 @@ if(BUILD_TESTS)
     COMMAND lua_test_ic_test "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/test_ic.lua"
   )
 
+  add_executable(chip8_core_test tests/chip8_core_test.cc)
+  target_link_libraries(chip8_core_test PRIVATE lua_static)
+  if(MSVC)
+    target_compile_options(chip8_core_test PRIVATE /EHsc)
+  endif()
+
+  add_test(
+    NAME chip8_core
+    COMMAND chip8_core_test
+            "${CMAKE_SOURCE_DIR}/examples/chip8/core.lua"
+            "${CMAKE_SOURCE_DIR}/examples/chip8/framebuffer.lua"
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/chip8_core_test.lua"
+  )
+
   add_executable(object_callback_test
     tests/object_callback_test.cc
     ${SRCDIR}/luabind/device/lua_event_dispatcher.cc

--- a/model/tests/README.md
+++ b/model/tests/README.md
@@ -3,7 +3,9 @@
 The test suite runs without Proteus by replacing SDK-facing pins with small
 in-process fakes. `fixtures/test_ic.lua` is a complete three-pin NAND model used
 to check the Lua model contract, lifecycle calls, timing declarations, truth
-table, and timer arguments.
+table, and timer arguments. The CHIP-8 test loads the portable example core into
+the bundled Lua runtime and exercises its instruction set, timers, input,
+framebuffer, compatibility profiles, and fault handling with deterministic ROMs.
 
 Configure and run the suite with Visual Studio's 32-bit generator:
 

--- a/model/tests/chip8_core_test.cc
+++ b/model/tests/chip8_core_test.cc
@@ -1,0 +1,41 @@
+#include <iostream>
+
+#include <lua.hpp>
+
+namespace
+{
+void setPath(lua_State *lua, const char *name, const char *path)
+{
+    lua_pushstring(lua, path);
+    lua_setglobal(lua, name);
+}
+} // namespace
+
+int main(int argumentCount, char **arguments)
+{
+    if (argumentCount != 4)
+    {
+        std::cerr << "Expected CHIP-8 core, framebuffer, and test script paths\n";
+        return 1;
+    }
+
+    auto *lua = luaL_newstate();
+    if (lua == nullptr)
+    {
+        return 1;
+    }
+    luaL_openlibs(lua);
+
+    setPath(lua, "CHIP8_CORE_PATH", arguments[1]);
+    setPath(lua, "CHIP8_FRAMEBUFFER_PATH", arguments[2]);
+
+    if (luaL_dofile(lua, arguments[3]) != LUA_OK)
+    {
+        std::cerr << lua_tostring(lua, -1) << '\n';
+        lua_close(lua);
+        return 1;
+    }
+
+    lua_close(lua);
+    return 0;
+}

--- a/model/tests/chip8_core_test.cc
+++ b/model/tests/chip8_core_test.cc
@@ -13,9 +13,9 @@ void setPath(lua_State *lua, const char *name, const char *path)
 
 int main(int argumentCount, char **arguments)
 {
-    if (argumentCount != 4)
+    if (argumentCount != 5)
     {
-        std::cerr << "Expected CHIP-8 core, framebuffer, and test script paths\n";
+        std::cerr << "Expected CHIP-8 core, framebuffer, device, and test script paths\n";
         return 1;
     }
 
@@ -28,8 +28,9 @@ int main(int argumentCount, char **arguments)
 
     setPath(lua, "CHIP8_CORE_PATH", arguments[1]);
     setPath(lua, "CHIP8_FRAMEBUFFER_PATH", arguments[2]);
+    setPath(lua, "CHIP8_DEVICE_PATH", arguments[3]);
 
-    if (luaL_dofile(lua, arguments[3]) != LUA_OK)
+    if (luaL_dofile(lua, arguments[4]) != LUA_OK)
     {
         std::cerr << lua_tostring(lua, -1) << '\n';
         lua_close(lua);

--- a/model/tests/fixtures/chip8_core_test.lua
+++ b/model/tests/fixtures/chip8_core_test.lua
@@ -247,6 +247,55 @@ local function test_faults()
     end)
 end
 
+local function test_device_stub()
+    local draw_count = 0
+    local repaint_count = 0
+    graphics = {
+        BLACK = 0,
+        WHITE = 1,
+        GREY = 2,
+        BRIGHTWHITE = 3,
+        BRIGHTGREEN = 4,
+        TXJ_LEFT = 0x01,
+        TXJ_CENTRE = 0x02,
+        TXJ_RIGHT = 0x04,
+        TXJ_MIDDLE = 0x08,
+        ACF_LEFT = 0x01,
+        set_draw_scale = function() end,
+        set_pen_width = function() end,
+        set_text_size = function() end,
+        set_pen_colour = function() end,
+        set_brush_colour = function() end,
+        set_text_colour = function() end,
+        draw_box = function()
+            draw_count = draw_count + 1
+        end,
+        draw_text = function()
+            draw_count = draw_count + 1
+        end,
+        repaint = function()
+            repaint_count = repaint_count + 1
+        end
+    }
+
+    dofile(CHIP8_DEVICE_PATH)
+    check(type(device_pins) == "table" and #device_pins == 0,
+          "device stub unexpectedly declared electrical pins")
+    check(type(device_init) == "function" and type(device_simulate) == "function",
+          "device lifecycle callbacks were not defined")
+    check(type(device_graphics_init) == "function" and type(device_graphics_plot) == "function" and
+          type(device_graphics_actuate) == "function", "device graphics callbacks were not defined")
+
+    device_graphics_init()
+    device_graphics_plot(0)
+    check(draw_count >= 20, "device stub did not draw the console face")
+    check(device_graphics_actuate(0, 222, 32, graphics.ACF_LEFT),
+          "device stub did not accept a keypad click")
+    check(repaint_count == 1, "keypad click did not request a repaint")
+    check(not device_graphics_actuate(0, 4, 4, graphics.ACF_LEFT),
+          "device stub accepted a click outside the keypad")
+end
+
 test_reset_and_framebuffer()
 test_arithmetic_and_logic()
 test_flow_control()
@@ -255,5 +304,6 @@ test_input_and_timers()
 test_random_and_quirks()
 test_drawing()
 test_faults()
+test_device_stub()
 
 assert(checks >= 50, "CHIP-8 test coverage unexpectedly shrank")

--- a/model/tests/fixtures/chip8_core_test.lua
+++ b/model/tests/fixtures/chip8_core_test.lua
@@ -1,0 +1,259 @@
+local Chip8 = assert(dofile(CHIP8_CORE_PATH))
+local Framebuffer = assert(dofile(CHIP8_FRAMEBUFFER_PATH))
+
+local checks = 0
+
+local function check(condition, message)
+    checks = checks + 1
+    assert(condition, message)
+end
+
+local function expect_error(fragment, action)
+    local success, message = pcall(action)
+    check(not success, "expected an error containing: " .. fragment)
+    check(tostring(message):find(fragment, 1, true) ~= nil, tostring(message))
+end
+
+local function encode(words)
+    local bytes = {}
+    for _, word in ipairs(words) do
+        bytes[#bytes + 1] = string.char((word >> 8) & 0xff, word & 0xff)
+    end
+    return table.concat(bytes)
+end
+
+local function machine(words, options)
+    options = options or {}
+    local display = options.display or Framebuffer.new(Chip8.DISPLAY_WIDTH, Chip8.DISPLAY_HEIGHT)
+    options.display = display
+    local vm = Chip8.new(options)
+    vm:load_rom(encode(words or {}))
+    return vm, display
+end
+
+local function test_reset_and_framebuffer()
+    local vm, display = machine({0x00e0})
+    check(vm.pc == Chip8.PROGRAM_ADDRESS, "program counter did not reset")
+    check(vm.i == 0 and vm.sp == 0 and vm.delay_timer == 0 and vm.sound_timer == 0,
+          "processor state did not reset")
+    check(vm:peek(Chip8.FONT_ADDRESS) == 0xf0, "font was not installed")
+    check(vm:peek(Chip8.FONT_ADDRESS + 79) == 0x80, "font tail was not installed")
+
+    local was_dirty = display:consume_dirty()
+    check(was_dirty, "new framebuffer was not dirty")
+    check(not display:consume_dirty(), "framebuffer dirty flag did not clear")
+    check(not display:xor_pixel(4, 5), "drawing an empty pixel reported a collision")
+    check(display:xor_pixel(4, 5), "erasing a lit pixel did not report a collision")
+    check(display:get_pixel(4, 5) == 0 and display:count_lit() == 0, "framebuffer XOR was incorrect")
+
+    local snapshot = display:snapshot()
+    check(snapshot.width == 64 and snapshot.height == 32 and snapshot.revision == 2,
+          "framebuffer snapshot metadata was incorrect")
+end
+
+local function test_arithmetic_and_logic()
+    local vm = machine({
+        0x60fe, 0x6102, 0x8014, 0x8015, 0x8017, 0x8011, 0x8012, 0x8013,
+        0x6203, 0x8206, 0x6280, 0x820e, 0x60ff, 0x7002, 0x8100
+    })
+
+    vm:run(2)
+    vm:step()
+    check(vm.v[0] == 0 and vm.v[0xf] == 1, "8XY4 carry was incorrect")
+    vm:step()
+    check(vm.v[0] == 0xfe and vm.v[0xf] == 0, "8XY5 borrow was incorrect")
+    vm:step()
+    check(vm.v[0] == 4 and vm.v[0xf] == 0, "8XY7 reverse subtraction was incorrect")
+    vm:step()
+    check(vm.v[0] == 6, "8XY1 OR was incorrect")
+    vm:step()
+    check(vm.v[0] == 2, "8XY2 AND was incorrect")
+    vm:step()
+    check(vm.v[0] == 0, "8XY3 XOR was incorrect")
+    vm:run(2)
+    check(vm.v[2] == 1 and vm.v[0xf] == 1, "8XY6 shift was incorrect")
+    vm:run(2)
+    check(vm.v[2] == 0 and vm.v[0xf] == 1, "8XYE shift was incorrect")
+    vm:run(2)
+    check(vm.v[0] == 1, "7XNN wrapping addition was incorrect")
+    vm:step()
+    check(vm.v[1] == 1, "8XY0 assignment was incorrect")
+end
+
+local function test_flow_control()
+    local vm = machine({
+        0x6001, 0x3001, 0x6000, 0x4001, 0x220e, 0x120c, 0x120c, 0x7001, 0x00ee
+    })
+    vm:step()
+    vm:step()
+    check(vm.pc == 0x206, "3XNN did not skip")
+    vm:step()
+    check(vm.pc == 0x208, "4XNN skipped on equality")
+    vm:step()
+    check(vm.pc == 0x20e and vm.sp == 1, "2NNN call was incorrect")
+    vm:step()
+    vm:step()
+    check(vm.v[0] == 2 and vm.pc == 0x20a and vm.sp == 0, "00EE return was incorrect")
+    vm:step()
+    check(vm.pc == 0x20c, "1NNN jump was incorrect")
+
+    vm = machine({0x6001, 0x6101, 0x5010, 0x6000, 0x6102, 0x9010, 0x6000})
+    vm:run(3)
+    check(vm.pc == 0x208, "5XY0 did not skip equal registers")
+    vm:run(2)
+    check(vm.pc == 0x20e, "9XY0 did not skip unequal registers")
+
+    vm = machine({0x6004, 0xb220})
+    vm:run(2)
+    check(vm.pc == 0x224, "BNNN V0-relative jump was incorrect")
+
+    vm = machine({0x0123, 0x6001})
+    vm:run(2)
+    check(vm.v[0] == 1, "0NNN compatibility no-op did not advance")
+end
+
+local function test_memory_and_fonts()
+    local vm = machine({
+        0xa300, 0x607b, 0xf033,
+        0x600a, 0x610b, 0x620c, 0xa310, 0xf255,
+        0x6000, 0x6100, 0x6200, 0xa310, 0xf265,
+        0x630a, 0xf329, 0x6301, 0xafff, 0xf31e
+    })
+    vm:run(3)
+    check(vm:peek(0x300) == 1 and vm:peek(0x301) == 2 and vm:peek(0x302) == 3,
+          "FX33 BCD conversion was incorrect")
+    vm:run(5)
+    check(vm:peek(0x310) == 0x0a and vm:peek(0x311) == 0x0b and vm:peek(0x312) == 0x0c,
+          "FX55 register store was incorrect")
+    check(vm.i == 0x310, "modern FX55 unexpectedly changed I")
+    vm:run(5)
+    check(vm.v[0] == 0x0a and vm.v[1] == 0x0b and vm.v[2] == 0x0c,
+          "FX65 register load was incorrect")
+    check(vm.i == 0x310, "modern FX65 unexpectedly changed I")
+    vm:run(2)
+    check(vm.i == Chip8.FONT_ADDRESS + 50, "FX29 font lookup was incorrect")
+    vm:run(3)
+    check(vm.i == 0, "FX1E did not wrap the 12-bit index")
+
+    vm = machine({0xa300, 0x6001, 0x6102, 0xf155}, {profile = "original"})
+    vm:run(4)
+    check(vm.i == 0x302, "original FX55 did not increment I")
+end
+
+local function test_input_and_timers()
+    local vm = machine({0xf10a, 0x6201})
+    vm:step()
+    check(vm.pc == 0x200 and vm.v[1] == 0, "FX0A did not wait for a key")
+    vm:set_key(5, true)
+    vm:step()
+    check(vm.pc == 0x202 and vm.v[1] == 5, "FX0A did not capture the pressed key")
+
+    vm = machine({0x600a, 0xe09e, 0x6101, 0x6102})
+    vm:step()
+    vm:set_key(0x0a, true)
+    vm:run(2)
+    check(vm.v[1] == 2, "EX9E did not skip for a pressed key")
+
+    vm = machine({0x600a, 0xe0a1, 0x6101, 0x6102})
+    vm:run(3)
+    check(vm.v[1] == 2, "EXA1 did not skip for a released key")
+
+    vm = machine({0x6003, 0xf015, 0xf018, 0xf007})
+    vm:run(4)
+    check(vm.v[0] == 3 and vm.delay_timer == 3 and vm.sound_timer == 3,
+          "timer instructions were incorrect")
+    local was_sounding, still_sounding = vm:tick_timers(2)
+    check(was_sounding and still_sounding and vm.delay_timer == 1 and vm.sound_timer == 1,
+          "timer tick did not decrement")
+    was_sounding, still_sounding = vm:tick_timers(2)
+    check(was_sounding and not still_sounding and vm.delay_timer == 0 and vm.sound_timer == 0,
+          "timers did not stop at zero")
+end
+
+local function test_random_and_quirks()
+    local vm = machine({0xc00f}, {random_byte = function()
+        return 0xab
+    end})
+    vm:step()
+    check(vm.v[0] == 0x0b, "CXNN random mask was incorrect")
+
+    vm = machine({0x6104, 0x6203, 0x8126})
+    vm:run(3)
+    check(vm.v[1] == 2 and vm.v[0xf] == 0, "modern shift source was incorrect")
+
+    vm = machine({0x6104, 0x6203, 0x8126}, {profile = "original"})
+    vm:run(3)
+    check(vm.v[1] == 1 and vm.v[0xf] == 1, "original shift source was incorrect")
+
+    vm = machine({0x6001, 0x6204, 0xb220}, {quirks = {jump_uses_vx = true}})
+    vm:run(3)
+    check(vm.pc == 0x224, "BXNN quirk did not use VX")
+end
+
+local function test_drawing()
+    local vm, display = machine({0xa300, 0x603e, 0x611f, 0xd011, 0xd011, 0x00e0})
+    vm:poke(0x300, 0xf0)
+    vm:run(4)
+    check(vm.v[0xf] == 0 and display:count_lit() == 4, "DXYN did not draw four pixels")
+    check(display:get_pixel(62, 31) == 1 and display:get_pixel(63, 31) == 1 and
+          display:get_pixel(0, 31) == 1 and display:get_pixel(1, 31) == 1,
+          "DXYN did not wrap at the display edge")
+    vm:step()
+    check(vm.v[0xf] == 1 and display:count_lit() == 0, "DXYN collision was incorrect")
+    display:xor_pixel(3, 3)
+    vm:step()
+    check(display:count_lit() == 0, "00E0 did not clear the display")
+
+    vm, display = machine({0xa300, 0x603e, 0x611f, 0xd011}, {quirks = {clip_sprites = true}})
+    vm:poke(0x300, 0xf0)
+    vm:run(4)
+    check(display:count_lit() == 2 and display:get_pixel(62, 31) == 1 and display:get_pixel(63, 31) == 1,
+          "sprite clipping quirk was incorrect")
+end
+
+local function test_faults()
+    expect_error("display", function()
+        Chip8.new({display = {}})
+    end)
+    expect_error("unknown CHIP-8 quirk", function()
+        machine({}, {quirks = {mystery = true}})
+    end)
+    expect_error("unsupported CHIP-8 opcode", function()
+        machine({0xf0ff}):step()
+    end)
+    expect_error("stack underflow", function()
+        machine({0x00ee}):step()
+    end)
+    expect_error("stack overflow", function()
+        machine({0x2200}):run(17)
+    end)
+    expect_error("does not fit", function()
+        local vm = machine({})
+        vm:load_rom(string.rep("\0", Chip8.MEMORY_SIZE - Chip8.PROGRAM_ADDRESS + 1))
+    end)
+    expect_error("memory write outside", function()
+        machine({0xafff, 0x60ff, 0xf033}):run(3)
+    end)
+    expect_error("random byte", function()
+        machine({0xc0ff}, {random_byte = function()
+            return 256
+        end}):step()
+    end)
+    expect_error("key", function()
+        machine({}):set_key(16, true)
+    end)
+    expect_error("instruction fetch outside", function()
+        machine({0x1fff}):run(2)
+    end)
+end
+
+test_reset_and_framebuffer()
+test_arithmetic_and_logic()
+test_flow_control()
+test_memory_and_fonts()
+test_input_and_timers()
+test_random_and_quirks()
+test_drawing()
+test_faults()
+
+assert(checks >= 50, "CHIP-8 test coverage unexpectedly shrank")


### PR DESCRIPTION
## What changed

- add a dependency-free Lua 5.4 CHIP-8 core implementing the classic instruction set
- add a small `clear()` / `xor_pixel(x, y)` display contract and headless framebuffer implementation
- separate 60 Hz timer ticks, input state, and deterministic random-byte injection from instruction execution
- support modern/original profiles plus sprite, jump, shift, and load/store quirks
- add a NAND-style Proteus device definition that loads `chip8/device.lua` through `openvsm.DLL`
- add a pinless visual host stub with an exact 3x 64-by-32 display area, status strip, and canonical hexadecimal keypad
- add a native CTest harness covering the VM and headless host-stub drawing and actuation
- document the future OpenVSM and ImGui adapter boundary and the intended Proteus device face

## Why

The emulator should not depend on Proteus drawing objects or a future ImGui implementation. Keeping the VM behind a tiny display contract lets both frontends share the same tested emulation state and timing model. The Proteus stub makes the eventual component layout concrete without coupling the unfinished ROM, timing, and input adapter to the core.

## User impact

The repository now contains a loadable `LUA_CHIP8` device skeleton. In Proteus it renders a compact virtual console that explicitly shows `NO ROM` and `HOST STUB`; keypad clicks highlight keys but do not drive the VM yet. The component currently has no electrical pins, and its DIL8 package entry is only a temporary library-metadata placeholder.

## Validation

- fresh Win32 Release configure and `chip8_core_test` build passed
- `chip8_core` CTest passed, including mocked graphics drawing and keypad hit-testing
- repository formatting check passed for 47 project-owned C/C++ files
- `git diff --check` passed
- the existing recursive installer rule includes `chip8/core.lua`, `chip8/framebuffer.lua`, and `chip8/device.lua`