### PR TITLE
Restore Release runtime logging

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCDIR cpp)
 
 set(DLL_SRC
   ${SRCDIR}/dllmain.cc
+  ${SRCDIR}/runtime_logging.cc
   ${SRCDIR}/active_model.cc
   ${SRCDIR}/model.cc
   ${SRCDIR}/luabind/device/bus.cc
@@ -101,6 +102,23 @@ lua_static
 tinyLog
 )
 if(BUILD_TESTS)
+  add_executable(runtime_logging_test
+    tests/runtime_logging_test.cc
+    ${SRCDIR}/runtime_logging.cc
+  )
+  target_include_directories(runtime_logging_test PRIVATE ${SRCDIR})
+  target_link_libraries(runtime_logging_test PRIVATE tinyLog)
+  if(MSVC)
+    target_compile_options(runtime_logging_test PRIVATE /EHsc)
+  endif()
+
+  set(RUNTIME_LOGGING_TEST_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/runtime_logging_test")
+  file(MAKE_DIRECTORY "${RUNTIME_LOGGING_TEST_DIRECTORY}")
+  add_test(NAME runtime_logging COMMAND runtime_logging_test)
+  set_tests_properties(runtime_logging PROPERTIES
+    WORKING_DIRECTORY "${RUNTIME_LOGGING_TEST_DIRECTORY}"
+  )
+
   add_executable(native_bus_test
     tests/native_bus_test.cc
     ${SRCDIR}/luabind/device/bus.cc

--- a/model/cpp/dllmain.cc
+++ b/model/cpp/dllmain.cc
@@ -1,9 +1,9 @@
 #include <windows.h>
-#include <fstream>
 #include <vsm.hpp>
 #include <log/log.hpp>
 #include "active_model.hpp"
 #include "model.hpp"
+#include "runtime_logging.hpp"
 
 namespace
 {
@@ -12,48 +12,13 @@ bool vsmRegister(ILICENCESERVER *ils)
     return ils && ils->authorize(0, VSM_API_VERSION);
 }
 
-void initializeRuntimeLogging() noexcept
-{
-    static const bool initialized = []() noexcept
-    {
-        try
-        {
-            std::ofstream logProbe("log.txt", std::ios::app);
-            if (logProbe.is_open())
-            {
-                logProbe.close();
-                Log::get().configure(TraceType::file);
-            }
-            else
-            {
-                Log::get().configure(TraceType::devnull);
-            }
-#ifdef OPENVSM_DEBUG
-            Log::get().set_level(TraceSeverity::debug);
-#endif
-            LOG_DEBUG("The model is being loaded\n");
-        }
-        catch (...)
-        {
-            try
-            {
-                Log::get().configure(TraceType::devnull);
-            }
-            catch (...)
-            {
-            }
-        }
-        return true;
-    }();
-    (void)initialized;
-}
 } // namespace
 
 extern "C"
 {
     IACTIVEMODEL __declspec(dllexport) * createactivemodel(char *device, ILICENCESERVER *ils)
     {
-        initializeRuntimeLogging();
+        DeviceSimulator::initializeRuntimeLogging();
         (void)device;
         if (!ils || !vsmRegister(ils))
         {
@@ -69,7 +34,7 @@ extern "C"
 
     IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
     {
-        initializeRuntimeLogging();
+        DeviceSimulator::initializeRuntimeLogging();
         (void)device;
         if (!vsmRegister(ils))
         {

--- a/model/cpp/runtime_logging.cc
+++ b/model/cpp/runtime_logging.cc
@@ -1,0 +1,41 @@
+#include "runtime_logging.hpp"
+
+#include <fstream>
+#include <log/log.hpp>
+
+namespace DeviceSimulator
+{
+void initializeRuntimeLogging() noexcept
+{
+    static const bool initialized = []() noexcept
+    {
+        try
+        {
+            std::ofstream logProbe("log.txt", std::ios::app);
+            if (logProbe.is_open())
+            {
+                logProbe.close();
+                Log::get().configure(TraceType::file);
+            }
+            else
+            {
+                Log::get().configure(TraceType::devnull);
+            }
+            Log::get().set_level(TraceSeverity::debug);
+            LOG_DEBUG("The model is being loaded\n");
+        }
+        catch (...)
+        {
+            try
+            {
+                Log::get().configure(TraceType::devnull);
+            }
+            catch (...)
+            {
+            }
+        }
+        return true;
+    }();
+    (void)initialized;
+}
+} // namespace DeviceSimulator

--- a/model/cpp/runtime_logging.hpp
+++ b/model/cpp/runtime_logging.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace DeviceSimulator
+{
+void initializeRuntimeLogging() noexcept;
+}

--- a/model/tests/README.md
+++ b/model/tests/README.md
@@ -6,6 +6,8 @@ to check the Lua model contract, lifecycle calls, timing declarations, truth
 table, and timer arguments. The CHIP-8 test loads the portable example core into
 the bundled Lua runtime and exercises its instruction set, timers, input,
 framebuffer, compatibility profiles, and fault handling with deterministic ROMs.
+The runtime-logging test verifies that the installed-build configuration writes
+its startup diagnostic instead of leaving an empty `log.txt`.
 
 Configure and run the suite with Visual Studio's 32-bit generator:
 

--- a/model/tests/runtime_logging_test.cc
+++ b/model/tests/runtime_logging_test.cc
@@ -1,0 +1,37 @@
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+
+#include "runtime_logging.hpp"
+
+int main()
+{
+    const std::filesystem::path logPath{"log.txt"};
+    std::error_code error;
+    std::filesystem::remove(logPath, error);
+    if (error)
+    {
+        std::cerr << "Could not remove the previous runtime log: " << error.message() << '\n';
+        return 1;
+    }
+
+    DeviceSimulator::initializeRuntimeLogging();
+
+    std::ifstream logFile{logPath, std::ios::binary};
+    if (!logFile.is_open())
+    {
+        std::cerr << "Runtime logging did not create log.txt\n";
+        return 1;
+    }
+
+    const std::string contents{std::istreambuf_iterator<char>{logFile}, std::istreambuf_iterator<char>{}};
+    if (contents.find("The model is being loaded") == std::string::npos)
+    {
+        std::cerr << "Runtime logging created log.txt but filtered the startup diagnostic\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## What changed

- enable debug diagnostics when runtime file logging is initialized in every build configuration
- move runtime logger initialization into a small testable module shared by the DLL factories
- add a regression test that verifies startup text is written to `log.txt`
- document the new runtime-logging test

## Root cause

When logger initialization was moved out of `DllMain`, enabling `TraceSeverity::debug` became conditional on `OPENVSM_DEBUG`. The installer contains the Release DLL, while model loading, Lua setup, pin registration, and failure diagnostics are emitted through `LOG_DEBUG`. Release therefore created `log.txt` successfully but filtered every startup/setup message.

## User impact

The installed 0.7 Release DLL once again writes model-loading and Lua setup diagnostics to the project `log.txt`, restoring the behavior used to diagnose NAND and CHIP-8 models.

## Validation

- the new test was run against the pre-fix condition and reproduced the empty-log failure
- focused Win32 Release runtime-logging test passed after the fix
- complete Win32 Release DLL build passed
- all 20 CTest tests passed
- repository formatting check passed for 50 project-owned C/C++ files
- `git diff --check` passed
