### PR TITLE
Prefer project-local Lua model scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ For a manual Visual Studio configuration, select the same target with
 Build outputs are written below `build/vs2022-win32/bin/<configuration>`.
 
 Each Proteus model selects its script with the component's `LUA` string property,
-for example `LUA=device.lua`. Relative values are resolved beneath `LUAVSM`;
-absolute paths are used directly. Paths may contain spaces and `LUAVSM` does not
-need a trailing slash. A missing property, script root, or readable script keeps
-that model out of simulation.
+for example `LUA=device.lua`. Relative values are resolved beside the Proteus
+project first, then beneath `LUAVSM`; this lets a project-local script override
+the installed default for that model. Absolute paths are used directly. Paths
+may contain spaces and `LUAVSM` does not need a trailing slash. A missing
+property or readable script keeps that model out of simulation, with every
+searched path recorded in `log.txt`.
 
 # License
 ----

--- a/docs/GRAPHICS-LUA-API.md
+++ b/docs/GRAPHICS-LUA-API.md
@@ -2,9 +2,9 @@
 
 OpenVSM can export a Proteus active model and a digital model from the same C++
 object and Lua state. Set the component's `LUA` property as for an ordinary v0.7
-model; relative paths are resolved below `LUAVSM`. Proteus calls the active
-model for drawing and user input while its digital side continues to receive
-pin simulation events.
+model; relative paths are resolved beside the Proteus project first and below
+`LUAVSM` second. Proteus calls the active model for drawing and user input while
+its digital side continues to receive pin simulation events.
 
 An active model may define any of these callbacks:
 

--- a/model/cpp/model.cc
+++ b/model/cpp/model.cc
@@ -124,8 +124,18 @@ void VirtualDevice::setup(IINSTANCE *instance, IDSIMCKT *dsim)
     constexpr char scriptProperty[] = "LUA";
     const char *configuredScript = instance_->getstrval(const_cast<char *>(scriptProperty));
     const char *scriptRoot = std::getenv("LUAVSM");
-    const auto scriptPath = resolveModelScriptPath(configuredScript == nullptr ? "" : configuredScript,
-                                                   scriptRoot == nullptr ? "" : scriptRoot);
+
+    std::error_code projectDirectoryError;
+    auto projectDirectory = std::filesystem::current_path(projectDirectoryError);
+    if (projectDirectoryError)
+    {
+        LOG_DEBUG("Failed to determine the Proteus project directory: {}\n", projectDirectoryError.message());
+        projectDirectory.clear();
+    }
+
+    const auto scriptPath =
+        resolveModelScriptPath(configuredScript == nullptr ? "" : configuredScript, projectDirectory,
+                               scriptRoot == nullptr ? std::filesystem::path{} : scriptRoot);
     if (!scriptPath)
     {
         LOG_DEBUG("Failed to select the model script: {}\n", scriptPath.error);

--- a/model/cpp/model_script_path.cc
+++ b/model/cpp/model_script_path.cc
@@ -1,40 +1,125 @@
 #include "model_script_path.hpp"
 
+#include <algorithm>
 #include <fstream>
+#include <vector>
+
+namespace
+{
+enum class CandidateState
+{
+    missing,
+    ready,
+    invalid
+};
+
+struct CandidateCheck
+{
+    CandidateState state;
+    std::string error;
+};
+
+CandidateCheck inspectCandidate(const std::filesystem::path &path)
+{
+    std::error_code statusError;
+    const bool exists = std::filesystem::exists(path, statusError);
+    if (statusError)
+    {
+        return {CandidateState::invalid,
+                "the model script path cannot be inspected: '" + path.string() + "' (" + statusError.message() + ")"};
+    }
+    if (!exists)
+    {
+        return {CandidateState::missing, {}};
+    }
+
+    const bool regularFile = std::filesystem::is_regular_file(path, statusError);
+    if (statusError)
+    {
+        return {CandidateState::invalid,
+                "the model script path cannot be inspected: '" + path.string() + "' (" + statusError.message() + ")"};
+    }
+    if (!regularFile)
+    {
+        return {CandidateState::invalid, "the model script is not a regular file: '" + path.string() + "'"};
+    }
+
+    std::ifstream script{path, std::ios::binary};
+    if (!script.is_open())
+    {
+        return {CandidateState::invalid, "the model script cannot be opened for reading: '" + path.string() + "'"};
+    }
+
+    return {CandidateState::ready, {}};
+}
+
+std::string missingScriptError(std::string_view configuredScript, const std::vector<std::filesystem::path> &candidates)
+{
+    std::string error = "the model script '" + std::string{configuredScript} + "' was not found; searched:";
+    for (const auto &candidate : candidates)
+    {
+        error += " '" + candidate.string() + "'";
+    }
+    return error;
+}
+} // namespace
 
 namespace DeviceSimulator
 {
-ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, std::string_view scriptRoot)
+ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, const std::filesystem::path &projectRoot,
+                                       const std::filesystem::path &scriptRoot)
 {
     if (configuredScript.empty())
     {
         return {{}, "the model's LUA property is empty"};
     }
 
-    std::filesystem::path path{configuredScript};
-    if (path.is_relative())
+    const std::filesystem::path configuredPath{configuredScript};
+    std::vector<std::filesystem::path> candidates;
+    if (configuredPath.is_absolute())
     {
-        if (scriptRoot.empty())
+        candidates.push_back(configuredPath.lexically_normal());
+    }
+    else
+    {
+        const auto addCandidate = [&](const std::filesystem::path &root)
         {
-            return {{}, "LUAVSM is not set for the relative script path '" + path.string() + "'"};
+            if (root.empty())
+            {
+                return;
+            }
+
+            const auto candidate = (root / configuredPath).lexically_normal();
+            if (std::find(candidates.begin(), candidates.end(), candidate) == candidates.end())
+            {
+                candidates.push_back(candidate);
+            }
+        };
+
+        addCandidate(projectRoot);
+        addCandidate(scriptRoot);
+    }
+
+    if (candidates.empty())
+    {
+        return {{},
+                "the relative model script '" + configuredPath.string() +
+                    "' cannot be resolved because neither the Proteus project directory nor LUAVSM is available"};
+    }
+
+    for (const auto &candidate : candidates)
+    {
+        const auto check = inspectCandidate(candidate);
+        if (check.state == CandidateState::ready)
+        {
+            return {candidate, {}};
         }
-        path = std::filesystem::path{scriptRoot} / path;
+        if (check.state == CandidateState::invalid)
+        {
+            return {candidate, check.error};
+        }
     }
 
-    path = path.lexically_normal();
-
-    std::error_code fileError;
-    if (!std::filesystem::is_regular_file(path, fileError))
-    {
-        return {path, "the model script is not a readable regular file: '" + path.string() + "'"};
-    }
-
-    std::ifstream script{path, std::ios::binary};
-    if (!script.is_open())
-    {
-        return {path, "the model script cannot be opened for reading: '" + path.string() + "'"};
-    }
-
-    return {path, {}};
+    return {candidates.front(), missingScriptError(configuredScript, candidates)};
 }
 } // namespace DeviceSimulator

--- a/model/cpp/model_script_path.hpp
+++ b/model/cpp/model_script_path.hpp
@@ -17,5 +17,6 @@ struct ModelScriptPath
     }
 };
 
-ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, std::string_view scriptRoot);
+ModelScriptPath resolveModelScriptPath(std::string_view configuredScript, const std::filesystem::path &projectRoot,
+                                       const std::filesystem::path &scriptRoot);
 } // namespace DeviceSimulator

--- a/model/tests/model_script_path_test.cc
+++ b/model/tests/model_script_path_test.cc
@@ -61,20 +61,35 @@ bool loadAndCheck(lua_State *lua, const std::filesystem::path &path, int expecte
 int main()
 {
     TemporaryDirectory scripts;
-    const auto firstScript = scripts.path() / "first model.lua";
-    const auto secondScript = scripts.path() / "second model.lua";
-    if (!writeScript(firstScript, 1) || !writeScript(secondScript, 2))
+    const auto projectRoot = scripts.path() / "project";
+    const auto installedRoot = scripts.path() / "installed";
+    std::filesystem::create_directories(projectRoot);
+    std::filesystem::create_directories(installedRoot);
+
+    const auto projectScript = projectRoot / "shared model.lua";
+    const auto shadowedInstalledScript = installedRoot / "shared model.lua";
+    const auto fallbackScript = installedRoot / "fallback model.lua";
+    const auto absoluteScript = scripts.path() / "absolute model.lua";
+    if (!writeScript(projectScript, 1) || !writeScript(shadowedInstalledScript, 2) || !writeScript(fallbackScript, 3) ||
+        !writeScript(absoluteScript, 4))
     {
         std::cerr << "Failed to create the test scripts\n";
         return 1;
     }
 
-    const auto first = DeviceSimulator::resolveModelScriptPath("first model.lua", scripts.path().string());
-    const auto second = DeviceSimulator::resolveModelScriptPath(secondScript.string(), "unused root");
-    if (!first || !second || first.path != firstScript.lexically_normal() ||
-        second.path != secondScript.lexically_normal())
+    const auto projectFirst = DeviceSimulator::resolveModelScriptPath("shared model.lua", projectRoot, installedRoot);
+    const auto installedFallback =
+        DeviceSimulator::resolveModelScriptPath("fallback model.lua", projectRoot, installedRoot);
+    const auto absolute =
+        DeviceSimulator::resolveModelScriptPath(absoluteScript.string(), "unused project", "unused root");
+    const auto projectOnly =
+        DeviceSimulator::resolveModelScriptPath("shared model.lua", projectRoot, std::filesystem::path{});
+    if (!projectFirst || !installedFallback || !absolute || !projectOnly ||
+        projectFirst.path != projectScript.lexically_normal() ||
+        installedFallback.path != fallbackScript.lexically_normal() ||
+        absolute.path != absoluteScript.lexically_normal() || projectOnly.path != projectScript.lexically_normal())
     {
-        std::cerr << "Failed to resolve distinct relative and absolute model scripts\n";
+        std::cerr << "Failed to apply project-first model script resolution\n";
         return 1;
     }
 
@@ -85,7 +100,8 @@ int main()
         return 1;
     }
 
-    const bool scriptsLoaded = loadAndCheck(lua, first.path, 1) && loadAndCheck(lua, second.path, 2);
+    const bool scriptsLoaded = loadAndCheck(lua, projectFirst.path, 1) &&
+                               loadAndCheck(lua, installedFallback.path, 3) && loadAndCheck(lua, absolute.path, 4);
     lua_close(lua);
     if (!scriptsLoaded)
     {
@@ -93,9 +109,28 @@ int main()
         return 1;
     }
 
-    const auto noRoot = DeviceSimulator::resolveModelScriptPath("relative.lua", {});
-    const auto missing = DeviceSimulator::resolveModelScriptPath("missing.lua", scripts.path().string());
-    if (noRoot || missing)
+    const auto missing = DeviceSimulator::resolveModelScriptPath("missing.lua", projectRoot, installedRoot);
+    const auto missingProjectPath = (projectRoot / "missing.lua").lexically_normal().string();
+    const auto missingInstalledPath = (installedRoot / "missing.lua").lexically_normal().string();
+    if (missing || missing.error.find(missingProjectPath) == std::string::npos ||
+        missing.error.find(missingInstalledPath) == std::string::npos)
+    {
+        std::cerr << "Missing-script diagnostics did not list every searched path\n";
+        return 1;
+    }
+
+    std::filesystem::create_directory(projectRoot / "blocked.lua");
+    if (!writeScript(installedRoot / "blocked.lua", 5))
+    {
+        std::cerr << "Failed to create the masked fallback script\n";
+        return 1;
+    }
+    const auto invalidProjectOverride =
+        DeviceSimulator::resolveModelScriptPath("blocked.lua", projectRoot, installedRoot);
+    const auto noRoot = DeviceSimulator::resolveModelScriptPath("relative.lua", {}, {});
+    const auto emptyProperty = DeviceSimulator::resolveModelScriptPath({}, projectRoot, installedRoot);
+    if (invalidProjectOverride || invalidProjectOverride.path != (projectRoot / "blocked.lua").lexically_normal() ||
+        noRoot || emptyProperty)
     {
         std::cerr << "Invalid script configuration was accepted\n";
         return 1;


### PR DESCRIPTION
## What changed

- resolve an absolute `LUA` property exactly as configured
- resolve a relative `LUA` property beside the Proteus project first
- fall back to the global `LUAVSM` directory when the project copy is absent
- preserve a present-but-invalid local override as an actionable error instead of silently loading another script
- list every searched candidate when a relative script is missing
- update the model and graphics documentation

## Root cause

OpenVSM already read the model-specific `LUA` value through `IINSTANCE::getstrval`, but the path resolver prepended `LUAVSM` to every relative value. Proteus runs with the project directory as its current directory, so project-local scripts were ignored even though other relative outputs such as `log.txt` appeared beside the project.

## User impact

A component configured with `LUA=device.lua` now loads `device.lua` beside its `.pdsprj`. Installed defaults such as `LUA=chip8/device.lua` continue to work through `LUAVSM`, while a project can override them by supplying the same relative path locally. Different devices continue to select independent scripts through their existing `LUA` properties.

## Validation

- focused `model_script_path` Release test passed
- complete Win32 Release DLL build passed
- all 20 CTest tests passed
- repository formatting check passed for 50 project-owned C/C++ files
- `git diff --check` passed
