### PR TITLE
Integrate the CHIP-8 Proteus device

### DIFF
--- a/examples/chip8/README.md
+++ b/examples/chip8/README.md
@@ -1,8 +1,9 @@
 # Portable CHIP-8 core
 
-This example starts with the emulator core rather than a Proteus-specific
-component. `core.lua` implements the classic 4 KiB, 64-by-32 CHIP-8 machine and
-depends only on Lua 5.4. ROMs are deliberately not included.
+This example keeps the emulator core independent from its Proteus-specific
+adapter. `core.lua` implements the classic 4 KiB, 64-by-32 CHIP-8 machine and
+depends only on Lua 5.4. `device.lua` supplies a small original demonstration
+program when no external ROM is configured.
 
 The core accepts a display object with two operations:
 
@@ -46,41 +47,45 @@ Execution is deterministic when `random_byte` is injected. Timers are separated
 from instruction execution so a Proteus callback, an ImGui event loop, or a
 headless test can drive the same core at an exact 60 Hz.
 
-## Proteus device stub
+## Proteus device
 
 `device.txt` follows the same Proteus library-description structure as the NAND
-example and loads `chip8/device.lua` through `openvsm.DLL`. The first version is
-a self-contained virtual console with no electrical pins. Its DIL8 package is a
-temporary metadata placeholder inherited from the NAND stub; the component is
-not yet intended for PCB placement.
+example and loads `chip8/device.lua` through `openvsm.DLL`. It is a
+self-contained virtual console with no electrical pins. Its DIL8 package is a
+temporary metadata placeholder inherited from the NAND example; the component
+is not intended for PCB placement.
+
+Leave the component's `ROM` property empty to run the built-in hexadecimal font
+demo. Set `ROM` to a binary CHIP-8 image to run another program. Relative paths
+are resolved by Proteus from the project directory, while absolute paths work
+unchanged. Because the property belongs to the component instance, multiple
+CHIP-8 devices can run different ROMs through the same `openvsm.dll`.
 
 The active schematic face is a compact horizontal console:
 
 ```text
 +--------------------------------------------------+
-| CHIP-8                                  HOST STUB |
+| CHIP-8                                       DEMO |
 | +----------------------------+   [1] [2] [3] [C] |
 | |                            |   [4] [5] [6] [D] |
-| |           NO ROM           |   [7] [8] [9] [E] |
+| |       framebuffer          |   [7] [8] [9] [E] |
 | |                            |   [A] [0] [B] [F] |
 | +----------------------------+                   |
-| STOP  PC:0200  60 Hz                             |
+| RUN  PC:0224  60 Hz  700 ips                     |
 +--------------------------------------------------+
 ```
 
 The 192-by-96 display area preserves the CHIP-8 2:1 aspect ratio and gives every
-64-by-32 framebuffer pixel an exact 3-by-3 drawing cell. Pixels will be lime on
-black. The status strip is reserved for run state, program counter, and timer
-rate. The canonical hexadecimal keypad is already drawn and responds visually
-to mouse clicks, but it is not connected to the VM until the host adapter is
-implemented. `NO ROM` and `HOST STUB` make that unfinished state explicit when
-the component is placed in Proteus.
+64-by-32 framebuffer pixel an exact 3-by-3 drawing cell. Pixels are lime on
+black. The adapter executes 700 instructions per second, updates CHIP-8 timers
+at exactly 60 Hz, and repaints only after framebuffer or keypad changes. Mouse
+clicks use the drawn hexadecimal keypad. Keyboard input uses the conventional
+`1234`, `QWER`, `ASDF`, `ZXCV` layout.
 
-## Planned host adapters
+## Host adapters
 
-- OpenVSM: map `device_graphics_plot` to the framebuffer, translate actuation
-  into the 16 CHIP-8 keys, call `graphics.repaint` only when dirty, and schedule
-  CPU/timer slices with simulation time.
+- OpenVSM: `device.lua` maps the framebuffer and keypad to the graphics API and
+  drives CPU/timer slices from Proteus absolute-time callbacks.
 - ImGui: render the same 64-by-32 snapshot as a scaled texture or draw list and
   map desktop keys to `set_key`.
 - Headless: use `framebuffer.lua`, as the native CTest harness does today.

--- a/examples/chip8/device.lua
+++ b/examples/chip8/device.lua
@@ -6,10 +6,28 @@ local SCREEN_LEFT = 12
 local SCREEN_TOP = 30
 local SCREEN_RIGHT = 204
 local SCREEN_BOTTOM = 126
+local SCREEN_SCALE = 3
 local KEYPAD_LEFT = 220
 local KEYPAD_TOP = 30
 local KEY_SIZE = 24
 local KEY_GAP = 4
+
+local TIMER_HZ = 60
+local CPU_HZ = 700
+local TIMER_EVENT = 0xc817
+
+local function sibling_path(name)
+    local source = debug.getinfo(1, "S").source
+    if source:sub(1, 1) == "@" then
+        source = source:sub(2)
+    end
+    local directory = source:match("^(.*[\\/])")
+    assert(directory ~= nil, "CHIP-8 device script directory is unavailable")
+    return directory .. name
+end
+
+local Chip8 = assert(dofile(sibling_path("core.lua")))
+local Framebuffer = assert(dofile(sibling_path("framebuffer.lua")))
 
 local keys = {
     {label = "1", value = 0x1},
@@ -30,12 +48,128 @@ local keys = {
     {label = "F", value = 0xf}
 }
 
+local keyboard_layout = {
+    {key = "1", value = 0x1}, {key = "2", value = 0x2}, {key = "3", value = 0x3}, {key = "4", value = 0xc},
+    {key = "Q", value = 0x4}, {key = "W", value = 0x5}, {key = "E", value = 0x6}, {key = "R", value = 0xd},
+    {key = "A", value = 0x7}, {key = "S", value = 0x8}, {key = "D", value = 0x9}, {key = "F", value = 0xe},
+    {key = "Z", value = 0xa}, {key = "X", value = 0x0}, {key = "C", value = 0xb}, {key = "V", value = 0xf}
+}
+local keyboard = {}
+for _, binding in ipairs(keyboard_layout) do
+    keyboard[string.byte(binding.key)] = binding.value
+    keyboard[string.byte(binding.key:lower())] = binding.value
+end
+
+-- This original 38-byte program draws the sixteen hexadecimal font glyphs.
+-- It makes a newly placed device visibly useful without distributing a ROM.
+local DEMO_ROM = string.char(
+    0x00, 0xe0, 0x60, 0x02, 0x61, 0x02, 0x62, 0x00,
+    0xf2, 0x29, 0xd0, 0x15, 0x70, 0x08, 0x72, 0x01,
+    0x32, 0x08, 0x12, 0x08, 0x60, 0x02, 0x61, 0x0c,
+    0xf2, 0x29, 0xd0, 0x15, 0x70, 0x08, 0x72, 0x01,
+    0x32, 0x10, 0x12, 0x18, 0x12, 0x24)
+
+local framebuffer
+local vm
+local running = false
+local fault_message
+local rom_label = "DEMO"
 local selected_key
+local pending_key_releases = {}
+local cpu_remainder = 0
+local timer_remainder = 0
+
+local timer_base = math.floor(SEC / TIMER_HZ)
+local timer_fraction = SEC % TIMER_HZ
+
+local function next_timer_interval()
+    timer_remainder = timer_remainder + timer_fraction
+    local correction = 0
+    if timer_remainder >= TIMER_HZ then
+        timer_remainder = timer_remainder - TIMER_HZ
+        correction = 1
+    end
+    return timer_base + correction
+end
+
+local function next_cpu_slice()
+    cpu_remainder = cpu_remainder + CPU_HZ
+    local instructions = math.floor(cpu_remainder / TIMER_HZ)
+    cpu_remainder = cpu_remainder % TIMER_HZ
+    return instructions
+end
+
+local function repaint()
+    if graphics ~= nil then
+        graphics.repaint(false)
+    end
+end
+
+local function stop_with_error(message)
+    running = false
+    fault_message = tostring(message)
+    print("CHIP-8 stopped: " .. fault_message)
+    if type(vsm_error) == "function" then
+        vsm_error("CHIP-8 stopped: " .. fault_message)
+    end
+    repaint()
+end
+
+local function read_rom(path)
+    local file, open_error = io.open(path, "rb")
+    if file == nil then
+        return nil, open_error
+    end
+
+    local bytes, read_error = file:read("*a")
+    file:close()
+    if bytes == nil then
+        return nil, read_error
+    end
+    return bytes
+end
+
+local function configured_rom()
+    local path = get_string_param("ROM")
+    if type(path) ~= "string" or path:match("%S") == nil then
+        return DEMO_ROM, "DEMO"
+    end
+
+    local bytes, load_error = read_rom(path)
+    if bytes == nil then
+        return nil, string.format("cannot read ROM '%s': %s", path, tostring(load_error))
+    end
+    return bytes, path:match("([^\\/]+)$") or path
+end
+
+local function release_keys()
+    if vm ~= nil then
+        for value in pairs(pending_key_releases) do
+            vm:set_key(value, false)
+        end
+    end
+    pending_key_releases = {}
+    if selected_key ~= nil then
+        selected_key = nil
+        repaint()
+    end
+end
+
+local function press_key(value)
+    if not running or vm == nil then
+        return false
+    end
+    vm:set_key(value, true)
+    pending_key_releases[value] = true
+    selected_key = value
+    repaint()
+    return true
+end
 
 local function key_bounds(index)
     local zero_based = index - 1
     local column = zero_based % 4
-    local row = zero_based // 4
+    local row = math.floor(zero_based / 4)
     local left = KEYPAD_LEFT + column * (KEY_SIZE + KEY_GAP)
     local top = KEYPAD_TOP + row * (KEY_SIZE + KEY_GAP)
     return left, top, left + KEY_SIZE, top + KEY_SIZE
@@ -49,14 +183,89 @@ local function draw_key(index, key)
     graphics.set_brush_colour(selected and graphics.BRIGHTGREEN or graphics.BLACK)
     graphics.draw_box(left, top, right, bottom)
     graphics.set_text_colour(selected and graphics.BLACK or graphics.BRIGHTWHITE)
-    graphics.draw_text((left + right) // 2, (top + bottom) // 2, 0,
+    graphics.draw_text(math.floor((left + right) / 2), math.floor((top + bottom) / 2), 0,
                        graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, key.label)
 end
 
+local function draw_framebuffer()
+    if framebuffer == nil then
+        return
+    end
+
+    local snapshot = framebuffer:snapshot()
+    graphics.set_pen_colour(graphics.BRIGHTGREEN)
+    graphics.set_brush_colour(graphics.BRIGHTGREEN)
+    for index, pixel in ipairs(snapshot.pixels) do
+        if pixel ~= 0 then
+            local zero_based = index - 1
+            local x = zero_based % snapshot.width
+            local y = math.floor(zero_based / snapshot.width)
+            local left = SCREEN_LEFT + x * SCREEN_SCALE
+            local top = SCREEN_TOP + y * SCREEN_SCALE
+            graphics.draw_box(left, top, left + SCREEN_SCALE, top + SCREEN_SCALE)
+        end
+    end
+end
+
 function device_init()
+    framebuffer = Framebuffer.new(Chip8.DISPLAY_WIDTH, Chip8.DISPLAY_HEIGHT)
+    vm = Chip8.new({
+        display = framebuffer,
+        profile = "modern",
+        random_byte = function()
+            return math.random(0, 255)
+        end
+    })
+    running = false
+    fault_message = nil
+    selected_key = nil
+    pending_key_releases = {}
+    cpu_remainder = 0
+    timer_remainder = 0
+
+    local rom, label_or_error = configured_rom()
+    if rom == nil then
+        rom_label = "ROM ERROR"
+        stop_with_error(label_or_error)
+        return
+    end
+
+    local loaded, load_error = pcall(vm.load_rom, vm, rom)
+    if not loaded then
+        rom_label = "ROM ERROR"
+        stop_with_error(load_error)
+        return
+    end
+
+    rom_label = label_or_error
+    running = true
+    print(string.format("CHIP-8 started: %s (%d bytes, %d instructions/s)", rom_label, #rom, CPU_HZ))
+    set_callback(systime() + next_timer_interval(), TIMER_EVENT)
 end
 
 function device_simulate()
+end
+
+function timer_callback(time, event_id)
+    if event_id ~= TIMER_EVENT or not running then
+        return
+    end
+
+    local executed, execution_error = pcall(function()
+        vm:run(next_cpu_slice())
+        vm:tick_timers(1)
+    end)
+    release_keys()
+
+    if not executed then
+        stop_with_error(execution_error)
+        return
+    end
+
+    if framebuffer:consume_dirty() then
+        repaint()
+    end
+    set_callback(time + next_timer_interval(), TIMER_EVENT)
 end
 
 function device_graphics_init()
@@ -72,22 +281,28 @@ function device_graphics_plot(_)
 
     graphics.set_text_colour(graphics.BRIGHTWHITE)
     graphics.draw_text(12, 14, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE, "CHIP-8")
-    graphics.draw_text(BODY_WIDTH - 12, 14, 0, graphics.TXJ_RIGHT | graphics.TXJ_MIDDLE,
-                       "HOST STUB")
+    graphics.draw_text(BODY_WIDTH - 12, 14, 0, graphics.TXJ_RIGHT | graphics.TXJ_MIDDLE, rom_label)
 
     graphics.set_pen_colour(graphics.BRIGHTGREEN)
     graphics.set_brush_colour(graphics.BLACK)
     graphics.draw_box(SCREEN_LEFT, SCREEN_TOP, SCREEN_RIGHT, SCREEN_BOTTOM)
-    graphics.set_text_colour(graphics.BRIGHTGREEN)
-    graphics.set_text_size(14)
-    graphics.draw_text((SCREEN_LEFT + SCREEN_RIGHT) // 2,
-                       (SCREEN_TOP + SCREEN_BOTTOM) // 2, 0,
-                       graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, "NO ROM")
+    draw_framebuffer()
+
+    if not running then
+        graphics.set_text_colour(graphics.BRIGHTGREEN)
+        graphics.set_text_size(14)
+        graphics.draw_text(math.floor((SCREEN_LEFT + SCREEN_RIGHT) / 2),
+                           math.floor((SCREEN_TOP + SCREEN_BOTTOM) / 2), 0,
+                           graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE,
+                           fault_message == nil and "STOPPED" or "ROM ERROR")
+    end
 
     graphics.set_text_size(10)
     graphics.set_text_colour(graphics.BRIGHTWHITE)
+    local state = running and "RUN" or (fault_message == nil and "STOP" or "ERROR")
+    local pc = vm == nil and Chip8.PROGRAM_ADDRESS or vm.pc
     graphics.draw_text(SCREEN_LEFT, 144, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE,
-                       "STOP  PC:0200  60 Hz")
+                       string.format("%s  PC:%04X  %d Hz  %d ips", state, pc, TIMER_HZ, CPU_HZ))
 
     for index, key in ipairs(keys) do
         draw_key(index, key)
@@ -97,17 +312,20 @@ end
 function device_graphics_animate(_, _, _)
 end
 
-function device_graphics_actuate(_, x, y, flags)
+function device_graphics_actuate(key, x, y, flags)
+    local keyboard_value = keyboard[key]
+    if keyboard_value ~= nil then
+        return press_key(keyboard_value)
+    end
+
     if (flags & graphics.ACF_LEFT) == 0 then
         return false
     end
 
-    for index, key in ipairs(keys) do
+    for index, keypad_key in ipairs(keys) do
         local left, top, right, bottom = key_bounds(index)
         if x >= left and x <= right and y >= top and y <= bottom then
-            selected_key = key.value
-            graphics.repaint(false)
-            return true
+            return press_key(keypad_key.value)
         end
     end
 

--- a/examples/chip8/device.txt
+++ b/examples/chip8/device.txt
@@ -9,6 +9,8 @@ NAME=LUA_CHIP8
 
 {LUA="LUA",STRING}
 
+{ROM="CHIP-8 ROM image (blank uses built-in demo)",STRING}
+
 {PRIMITIVE="Primitive Type",HIDDEN STRING}
 
 {PACKAGE="PCB Package",PACKAGE,0}
@@ -30,5 +32,7 @@ NAME=LUA_CHIP8
 {MODDLL=openvsm.DLL}
 {
 LUA=chip8/device.lua}
+
+{ROM=}
 
 {PACKAGE=DIL8}

--- a/model/tests/fixtures/chip8_core_test.lua
+++ b/model/tests/fixtures/chip8_core_test.lua
@@ -247,9 +247,33 @@ local function test_faults()
     end)
 end
 
-local function test_device_stub()
+local function test_device_adapter()
     local draw_count = 0
     local repaint_count = 0
+    local drawn_text = {}
+    local callbacks = {}
+    local errors = {}
+    local messages = {}
+    local configured_rom_path = ""
+
+    SEC = 1000000000000
+    get_string_param = function(name)
+        check(name == "ROM", "device requested an unexpected model property")
+        return configured_rom_path
+    end
+    systime = function()
+        return 5000
+    end
+    set_callback = function(time, event_id)
+        callbacks[#callbacks + 1] = {time = time, event_id = event_id}
+    end
+    vsm_error = function(message)
+        errors[#errors + 1] = message
+    end
+    print = function(message)
+        messages[#messages + 1] = tostring(message)
+    end
+
     graphics = {
         BLACK = 0,
         WHITE = 1,
@@ -270,8 +294,9 @@ local function test_device_stub()
         draw_box = function()
             draw_count = draw_count + 1
         end,
-        draw_text = function()
+        draw_text = function(_, _, _, _, text)
             draw_count = draw_count + 1
+            drawn_text[#drawn_text + 1] = text
         end,
         repaint = function()
             repaint_count = repaint_count + 1
@@ -280,20 +305,63 @@ local function test_device_stub()
 
     dofile(CHIP8_DEVICE_PATH)
     check(type(device_pins) == "table" and #device_pins == 0,
-          "device stub unexpectedly declared electrical pins")
+          "device adapter unexpectedly declared electrical pins")
     check(type(device_init) == "function" and type(device_simulate) == "function",
           "device lifecycle callbacks were not defined")
-    check(type(device_graphics_init) == "function" and type(device_graphics_plot) == "function" and
-          type(device_graphics_actuate) == "function", "device graphics callbacks were not defined")
+    check(type(timer_callback) == "function" and type(device_graphics_init) == "function" and
+          type(device_graphics_plot) == "function" and type(device_graphics_actuate) == "function",
+          "device timer or graphics callbacks were not defined")
 
+    device_init()
     device_graphics_init()
+    check(#callbacks == 1 and callbacks[1].time > systime(), "device did not schedule its first timer tick")
+    check(#messages == 1 and messages[1]:find("DEMO", 1, true) ~= nil,
+          "device did not report the built-in demo")
+
+    draw_count = 0
     device_graphics_plot(0)
-    check(draw_count >= 20, "device stub did not draw the console face")
+    local empty_display_draw_count = draw_count
+    check(empty_display_draw_count >= 20, "device adapter did not draw the console face")
+
+    for index = 1, 60 do
+        local scheduled = callbacks[index]
+        check(scheduled ~= nil, "device stopped scheduling timer ticks")
+        timer_callback(scheduled.time, scheduled.event_id)
+    end
+    check(#callbacks == 61, "device did not maintain its 60 Hz timer chain")
+    check(callbacks[61].time - callbacks[1].time == SEC,
+          "device timer accumulated drift over one second")
+    check(repaint_count > 0, "framebuffer changes did not request a repaint")
+
+    draw_count = 0
+    drawn_text = {}
+    device_graphics_plot(0)
+    check(draw_count > empty_display_draw_count + 20, "built-in demo did not render framebuffer pixels")
+    local status_text = table.concat(drawn_text, " ")
+    check(status_text:find("DEMO", 1, true) ~= nil and status_text:find("RUN", 1, true) ~= nil,
+          "device did not render its ROM and run status")
+
+    local repaint_before_key = repaint_count
     check(device_graphics_actuate(0, 222, 32, graphics.ACF_LEFT),
-          "device stub did not accept a keypad click")
-    check(repaint_count == 1, "keypad click did not request a repaint")
+          "device adapter did not accept a keypad click")
+    check(repaint_count == repaint_before_key + 1, "keypad click did not request a repaint")
+    timer_callback(callbacks[61].time, callbacks[61].event_id)
+    check(repaint_count > repaint_before_key + 1, "keypad pulse was not released on the next timer tick")
+    check(device_graphics_actuate(string.byte("x"), 0, 0, 0),
+          "device adapter did not accept the conventional keyboard layout")
     check(not device_graphics_actuate(0, 4, 4, graphics.ACF_LEFT),
-          "device stub accepted a click outside the keypad")
+          "device adapter accepted a click outside the keypad")
+
+    configured_rom_path = "__openvsm_missing_chip8_rom__.ch8"
+    local callback_count = #callbacks
+    device_init()
+    check(#callbacks == callback_count, "device scheduled execution after a ROM load failure")
+    check(#errors == 1 and errors[1]:find(configured_rom_path, 1, true) ~= nil,
+          "device did not report the failing per-instance ROM path")
+    drawn_text = {}
+    device_graphics_plot(0)
+    check(table.concat(drawn_text, " "):find("ROM ERROR", 1, true) ~= nil,
+          "device did not display its ROM error state")
 end
 
 test_reset_and_framebuffer()
@@ -304,6 +372,6 @@ test_input_and_timers()
 test_random_and_quirks()
 test_drawing()
 test_faults()
-test_device_stub()
+test_device_adapter()
 
-assert(checks >= 50, "CHIP-8 test coverage unexpectedly shrank")
+assert(checks >= 120, "CHIP-8 test coverage unexpectedly shrank")


### PR DESCRIPTION
## What changed

- wire the portable CHIP-8 core and framebuffer into the Proteus device adapter
- run a small original demo when the per-instance `ROM` property is blank
- load relative or absolute external ROM paths per component instance
- execute at 700 instructions/s with exact 60 Hz timer scheduling
- render the 64×32 framebuffer and connect mouse plus `1234`/`QWER`/`ASDF`/`ZXCV` keyboard input
- surface ROM and runtime failures through the device UI and host error reporting
- expand the headless CHIP-8 test to cover scheduling, rendering, input pulses, and ROM errors

## Why

The existing component was intentionally only a graphical stub: its initialization and simulation callbacks did not instantiate or execute the CHIP-8 core. This completes the first OpenVSM host adapter while keeping the VM and framebuffer portable for a later ImGui frontend.

## Validation

- `cmake --build build/runtime-logging-test --config Release`
- `ctest --test-dir build/runtime-logging-test -C Release --output-on-failure` — 20/20 passed
- `cmake --build build/installer-release --config Release --target BuildInstaller`
- `git diff --check`