### PR TITLE
Trace active graphics lifecycle

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -318,15 +318,21 @@ if(BUILD_TESTS)
   add_executable(graphics_lua_api_test
     tests/graphics_lua_api_test.cc
     ${SRCDIR}/luabind/graphics_lua_api.cc
+    ${SRCDIR}/runtime_logging.cc
   )
   target_include_directories(graphics_lua_api_test PRIVATE
     ${SRCDIR}
     ${CMAKE_SOURCE_DIR}/externals/sdk
   )
-  target_link_libraries(graphics_lua_api_test PRIVATE lua_static)
+  target_link_libraries(graphics_lua_api_test PRIVATE lua_static tinyLog)
   if(MSVC)
     target_compile_options(graphics_lua_api_test PRIVATE /EHsc)
   endif()
 
   add_test(NAME graphics_lua_api COMMAND graphics_lua_api_test)
+  set(GRAPHICS_LUA_API_TEST_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/graphics_lua_api_test")
+  file(MAKE_DIRECTORY "${GRAPHICS_LUA_API_TEST_DIRECTORY}")
+  set_tests_properties(graphics_lua_api PROPERTIES
+    WORKING_DIRECTORY "${GRAPHICS_LUA_API_TEST_DIRECTORY}"
+  )
 endif()

--- a/model/cpp/active_model.cc
+++ b/model/cpp/active_model.cc
@@ -1,17 +1,23 @@
 #include "active_model.hpp"
 
+#include <format>
+
 #include "luabind/graphics_lua_api.hpp"
+#include "runtime_logging.hpp"
 
 namespace DeviceSimulator
 {
 void LuaActiveModel::initialize(ICOMPONENT *component)
 {
     component_ = component;
-    if (component_)
+    if (!component_)
     {
-        registerGraphicsLuaApi(getLuaContext(), component_);
-        ensureGraphicsInitialized();
+        logRuntimeDebug("Active model initialization did not receive a Proteus component surface");
+        return;
     }
+
+    logRuntimeDebug("Active model received the Proteus component surface");
+    registerGraphicsLuaApi(getLuaContext(), component_);
 }
 
 ISPICEMODEL *LuaActiveModel::getspicemodel(CHAR *primitive)
@@ -22,43 +28,77 @@ ISPICEMODEL *LuaActiveModel::getspicemodel(CHAR *primitive)
 
 IDSIMMODEL *LuaActiveModel::getdsimmodel(CHAR *primitive)
 {
-    (void)primitive;
+    logRuntimeDebug(std::format("Active model attached its digital interface for primitive {}",
+                                primitive && *primitive ? primitive : "<unknown>"));
     return this;
 }
 
 void LuaActiveModel::plot(ACTIVESTATE state)
 {
+    if (!firstPlotLogged_)
+    {
+        logRuntimeDebug(std::format("Active model received its first plot request with state {}", state));
+        firstPlotLogged_ = true;
+    }
+    if (!simulationReadyForGraphics_)
+    {
+        return;
+    }
     ensureGraphicsInitialized();
     dispatchLuaGraphicsPlot(getLuaContext(), state);
 }
 
 void LuaActiveModel::animate(INT element, ACTIVEDATA *newstate)
 {
+    if (!firstAnimationLogged_)
+    {
+        logRuntimeDebug(std::format("Active model received its first animation event for element {}", element));
+        firstAnimationLogged_ = true;
+    }
+    if (!simulationReadyForGraphics_)
+    {
+        return;
+    }
     ensureGraphicsInitialized();
     dispatchLuaGraphicsAnimate(getLuaContext(), element, newstate);
 }
 
 BOOL LuaActiveModel::actuate(WORD key, INT x, INT y, DWORD flags)
 {
+    if (!firstActuationLogged_)
+    {
+        logRuntimeDebug("Active model received its first actuation event");
+        firstActuationLogged_ = true;
+    }
+    if (!simulationReadyForGraphics_)
+    {
+        return FALSE;
+    }
     ensureGraphicsInitialized();
     return dispatchLuaGraphicsActuate(getLuaContext(), key, x, y, flags) ? TRUE : FALSE;
 }
 
 void LuaActiveModel::setup(IINSTANCE *instance, IDSIMCKT *dsim)
 {
+    logRuntimeDebug("Setting up the active model simulation interface");
     if (component_)
     {
         registerGraphicsLuaApi(getLuaContext(), component_);
     }
     VirtualDevice::setup(instance, dsim);
+    simulationReadyForGraphics_ = true;
     ensureGraphicsInitialized();
 }
 
 void LuaActiveModel::ensureGraphicsInitialized()
 {
-    if (!graphicsInitialized_)
+    if (simulationReadyForGraphics_ && !graphicsInitialized_)
     {
         graphicsInitialized_ = dispatchLuaGraphicsInit(getLuaContext());
+        if (graphicsInitialized_)
+        {
+            logRuntimeDebug("Lua graphics initialization completed");
+        }
     }
 }
 } // namespace DeviceSimulator

--- a/model/cpp/active_model.hpp
+++ b/model/cpp/active_model.hpp
@@ -20,6 +20,10 @@ class LuaActiveModel final : public VirtualDevice, public IACTIVEMODEL
     void ensureGraphicsInitialized();
 
     ICOMPONENT *component_ = nullptr;
+    bool simulationReadyForGraphics_ = false;
     bool graphicsInitialized_ = false;
+    bool firstPlotLogged_ = false;
+    bool firstAnimationLogged_ = false;
+    bool firstActuationLogged_ = false;
 };
 } // namespace DeviceSimulator

--- a/model/cpp/dllmain.cc
+++ b/model/cpp/dllmain.cc
@@ -12,6 +12,11 @@ bool vsmRegister(ILICENCESERVER *ils)
     return ils && ils->authorize(0, VSM_API_VERSION);
 }
 
+const char *deviceName(const char *device)
+{
+    return device && *device ? device : "<unknown>";
+}
+
 } // namespace
 
 extern "C"
@@ -19,9 +24,10 @@ extern "C"
     IACTIVEMODEL __declspec(dllexport) * createactivemodel(char *device, ILICENCESERVER *ils)
     {
         DeviceSimulator::initializeRuntimeLogging();
-        (void)device;
+        LOG_DEBUG("Creating active model for device {}\n", deviceName(device));
         if (!ils || !vsmRegister(ils))
         {
+            LOG_DEBUG("VSM authorization failed; active model creation refused\n");
             return nullptr;
         }
         return new DeviceSimulator::LuaActiveModel;
@@ -35,7 +41,7 @@ extern "C"
     IDSIMMODEL __declspec(dllexport) * createdsimmodel(char *device, ILICENCESERVER *ils)
     {
         DeviceSimulator::initializeRuntimeLogging();
-        (void)device;
+        LOG_DEBUG("Creating digital model for device {}\n", deviceName(device));
         if (!vsmRegister(ils))
         {
             LOG_DEBUG("VSM authorization failed; model creation refused\n");

--- a/model/cpp/luabind/graphics_lua_api.cc
+++ b/model/cpp/luabind/graphics_lua_api.cc
@@ -1,6 +1,9 @@
 #include "graphics_lua_api.hpp"
 
 #include <cstdint>
+#include <string>
+
+#include "runtime_logging.hpp"
 
 namespace
 {
@@ -211,6 +214,39 @@ bool pushCallback(lua_State *lua, const char *name)
     return false;
 }
 
+bool claimCallbackDiagnostic(lua_State *lua, const char *name, const char *kind)
+{
+    const std::string key = std::string{"openvsm.graphics."} + name + '.' + kind;
+    lua_getfield(lua, LUA_REGISTRYINDEX, key.c_str());
+    const bool reported = lua_toboolean(lua, -1) != 0;
+    lua_pop(lua, 1);
+    if (!reported)
+    {
+        lua_pushboolean(lua, 1);
+        lua_setfield(lua, LUA_REGISTRYINDEX, key.c_str());
+    }
+    return !reported;
+}
+
+void reportMissingCallbackOnce(lua_State *lua, const char *name)
+{
+    if (claimCallbackDiagnostic(lua, name, "missing"))
+    {
+        DeviceSimulator::logRuntimeDebug(std::string{"Lua graphics callback "} + name + " is not defined");
+    }
+}
+
+void reportCallbackFailureOnce(lua_State *lua, const char *name)
+{
+    const char *rawMessage = lua_tostring(lua, -1);
+    const std::string message = rawMessage ? rawMessage : "unknown Lua error";
+    if (claimCallbackDiagnostic(lua, name, "failure"))
+    {
+        DeviceSimulator::logRuntimeDebug(std::string{"Lua graphics callback "} + name + " failed with \"" + message +
+                                         '"');
+    }
+}
+
 void setTableInteger(lua_State *lua, const char *name, lua_Integer value)
 {
     lua_pushinteger(lua, value);
@@ -397,9 +433,14 @@ bool dispatchLuaGraphicsInit(lua_State *lua)
     StackRestore restore(lua);
     if (!pushCallback(lua, "device_graphics_init"))
     {
+        reportMissingCallbackOnce(lua, "device_graphics_init");
         return false;
     }
-    lua_pcall(lua, 0, 0, 0);
+    if (lua_pcall(lua, 0, 0, 0) != LUA_OK)
+    {
+        reportCallbackFailureOnce(lua, "device_graphics_init");
+        return false;
+    }
     return true;
 }
 
@@ -413,10 +454,14 @@ void dispatchLuaGraphicsPlot(lua_State *lua, ACTIVESTATE state)
     StackRestore restore(lua);
     if (!pushCallback(lua, "device_graphics_plot"))
     {
+        reportMissingCallbackOnce(lua, "device_graphics_plot");
         return;
     }
     lua_pushinteger(lua, state);
-    lua_pcall(lua, 1, 0, 0);
+    if (lua_pcall(lua, 1, 0, 0) != LUA_OK)
+    {
+        reportCallbackFailureOnce(lua, "device_graphics_plot");
+    }
 }
 
 void dispatchLuaGraphicsAnimate(lua_State *lua, INT element, const ACTIVEDATA *data)
@@ -434,7 +479,10 @@ void dispatchLuaGraphicsAnimate(lua_State *lua, INT element, const ACTIVEDATA *d
     lua_pushinteger(lua, element);
     lua_pushinteger(lua, data ? data->type : ADT_VOID);
     pushActiveData(lua, data);
-    lua_pcall(lua, 3, 0, 0);
+    if (lua_pcall(lua, 3, 0, 0) != LUA_OK)
+    {
+        reportCallbackFailureOnce(lua, "device_graphics_animate");
+    }
 }
 
 bool dispatchLuaGraphicsActuate(lua_State *lua, WORD key, INT x, INT y, DWORD flags)
@@ -455,6 +503,7 @@ bool dispatchLuaGraphicsActuate(lua_State *lua, WORD key, INT x, INT y, DWORD fl
     lua_pushinteger(lua, flags);
     if (lua_pcall(lua, 4, 1, 0) != LUA_OK)
     {
+        reportCallbackFailureOnce(lua, "device_graphics_actuate");
         return false;
     }
     return lua_toboolean(lua, -1) != 0;

--- a/model/cpp/runtime_logging.cc
+++ b/model/cpp/runtime_logging.cc
@@ -38,4 +38,15 @@ void initializeRuntimeLogging() noexcept
     }();
     (void)initialized;
 }
+
+void logRuntimeDebug(std::string_view message) noexcept
+{
+    try
+    {
+        LOG_DEBUG("{}\n", message);
+    }
+    catch (...)
+    {
+    }
+}
 } // namespace DeviceSimulator

--- a/model/cpp/runtime_logging.hpp
+++ b/model/cpp/runtime_logging.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <string_view>
+
 namespace DeviceSimulator
 {
 void initializeRuntimeLogging() noexcept;
-}
+void logRuntimeDebug(std::string_view message) noexcept;
+} // namespace DeviceSimulator

--- a/model/tests/graphics_lua_api_test.cc
+++ b/model/tests/graphics_lua_api_test.cc
@@ -2,8 +2,13 @@
 
 #include <cstdarg>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string>
+
+#include "runtime_logging.hpp"
 
 namespace
 {
@@ -225,10 +230,26 @@ lua_Integer globalInteger(lua_State *lua, const char *name)
     lua_pop(lua, 1);
     return result;
 }
+
+std::size_t countOccurrences(const std::string &text, const std::string &needle)
+{
+    std::size_t count = 0;
+    for (std::size_t position = 0; (position = text.find(needle, position)) != std::string::npos;
+         position += needle.size())
+    {
+        ++count;
+    }
+    return count;
+}
 } // namespace
 
 int main()
 {
+    const std::filesystem::path logPath{"log.txt"};
+    std::error_code fileError;
+    std::filesystem::remove(logPath, fileError);
+    DeviceSimulator::initializeRuntimeLogging();
+
     lua_State *lua = luaL_newstate();
     if (!expect(lua != nullptr, "Lua state creation failed"))
     {
@@ -319,7 +340,19 @@ int main()
     ok = run(lua, "function device_graphics_actuate() error('boom') end") && ok;
     ok = expect(!DeviceSimulator::dispatchLuaGraphicsActuate(lua, 0, 0, 0, 0),
                 "throwing actuate callback was accepted") &&
+         expect(!DeviceSimulator::dispatchLuaGraphicsActuate(lua, 0, 0, 0, 0),
+                "repeated throwing actuate callback was accepted") &&
          expect(lua_gettop(lua) == initialTop, "throwing callback changed the Lua stack") && ok;
+
+    std::ifstream diagnosticFile{logPath, std::ios::binary};
+    const std::string diagnosticContents{std::istreambuf_iterator<char>{diagnosticFile},
+                                         std::istreambuf_iterator<char>{}};
+    ok = expect(diagnosticContents.find("device_graphics_actuate failed") != std::string::npos,
+                "throwing callback name was not logged") &&
+         expect(diagnosticContents.find("boom") != std::string::npos, "throwing callback error was not logged") &&
+         expect(countOccurrences(diagnosticContents, "device_graphics_actuate failed") == 1,
+                "throwing callback diagnostic was logged more than once") &&
+         ok;
 
     lua_close(lua);
     return ok ? 0 : 1;

--- a/model/tests/runtime_logging_test.cc
+++ b/model/tests/runtime_logging_test.cc
@@ -18,6 +18,7 @@ int main()
     }
 
     DeviceSimulator::initializeRuntimeLogging();
+    DeviceSimulator::logRuntimeDebug("Lua graphics callback diagnostic");
 
     std::ifstream logFile{logPath, std::ios::binary};
     if (!logFile.is_open())
@@ -30,6 +31,11 @@ int main()
     if (contents.find("The model is being loaded") == std::string::npos)
     {
         std::cerr << "Runtime logging created log.txt but filtered the startup diagnostic\n";
+        return 1;
+    }
+    if (contents.find("Lua graphics callback diagnostic") == std::string::npos)
+    {
+        std::cerr << "Runtime logging filtered the graphics callback diagnostic\n";
         return 1;
     }
 


### PR DESCRIPTION
## What changed

- Distinguish active-model and digital-model construction in the runtime log.
- Trace the Proteus component surface, combined digital interface, active setup, and the first plot, animation, and actuation callbacks.
- Report missing required graphics callbacks and Lua callback failures.
- Store diagnostic markers in each Lua registry so repeated repaint failures are logged only once.
- Delay `device_graphics_init` until both the component surface and Lua script are available.

## Why

The previous log showed only the shared `VirtualDevice` lifecycle, so a healthy digital model was indistinguishable from an active model that Proteus never created. Lua graphics callback errors were also discarded after `lua_pcall`, leaving a blank component with no actionable error.

## Impact

The next Proteus run will identify whether graphics fail at active DLL loading, component initialization, plotting, or inside Lua. Normal repaint loops do not produce repetitive lifecycle or callback-failure messages.

## Validation

- Release Win32 build completed successfully.
- `ctest --test-dir build/runtime-logging-test -C Release --output-on-failure` (20/20 passed).
- Graphics test verifies callback name/error logging and one-time suppression.
- `git diff --check`.