### PR TITLE
Correct CHIP-8 Proteus Y coordinates

### DIFF
--- a/examples/chip8/README.md
+++ b/examples/chip8/README.md
@@ -87,6 +87,10 @@ at exactly 60 Hz, and repaints only after framebuffer or keypad changes. Mouse
 clicks use the drawn hexadecimal keypad. Keyboard input uses the conventional
 `1234`, `QWER`, `ASDF`, `ZXCV` layout.
 
+The layout remains in portable top-left-origin coordinates. The Proteus adapter
+converts drawing and mouse-input Y coordinates at its boundary because the VSM
+component surface uses a bottom-left origin.
+
 ## Host adapters
 
 - OpenVSM: `device.lua` maps the framebuffer and keypad to the graphics API and

--- a/examples/chip8/device.lua
+++ b/examples/chip8/device.lua
@@ -82,6 +82,21 @@ local timer_remainder = 0
 local timer_base = math.floor(SEC / TIMER_HZ)
 local timer_fraction = SEC % TIMER_HZ
 
+-- The portable layout uses the usual top-left origin. Proteus drawing and
+-- actuation coordinates use a bottom-left origin, so conversion stays at this
+-- adapter boundary.
+local function proteus_y(layout_y)
+    return BODY_HEIGHT - layout_y
+end
+
+local function draw_layout_box(left, top, right, bottom)
+    graphics.draw_box(left, proteus_y(bottom), right, proteus_y(top))
+end
+
+local function draw_layout_text(x, y, rotation, justification, text)
+    graphics.draw_text(x, proteus_y(y), rotation, justification, text)
+end
+
 local function next_timer_interval()
     timer_remainder = timer_remainder + timer_fraction
     local correction = 0
@@ -181,10 +196,10 @@ local function draw_key(index, key)
 
     graphics.set_pen_colour(selected and graphics.BRIGHTGREEN or graphics.WHITE)
     graphics.set_brush_colour(selected and graphics.BRIGHTGREEN or graphics.BLACK)
-    graphics.draw_box(left, top, right, bottom)
+    draw_layout_box(left, top, right, bottom)
     graphics.set_text_colour(selected and graphics.BLACK or graphics.BRIGHTWHITE)
-    graphics.draw_text(math.floor((left + right) / 2), math.floor((top + bottom) / 2), 0,
-                       graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, key.label)
+    draw_layout_text(math.floor((left + right) / 2), math.floor((top + bottom) / 2), 0,
+                     graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE, key.label)
 end
 
 local function draw_framebuffer()
@@ -202,7 +217,7 @@ local function draw_framebuffer()
             local y = math.floor(zero_based / snapshot.width)
             local left = SCREEN_LEFT + x * SCREEN_SCALE
             local top = SCREEN_TOP + y * SCREEN_SCALE
-            graphics.draw_box(left, top, left + SCREEN_SCALE, top + SCREEN_SCALE)
+            draw_layout_box(left, top, left + SCREEN_SCALE, top + SCREEN_SCALE)
         end
     end
 end
@@ -277,32 +292,32 @@ end
 function device_graphics_plot(_)
     graphics.set_pen_colour(graphics.BRIGHTWHITE)
     graphics.set_brush_colour(graphics.GREY)
-    graphics.draw_box(0, 0, BODY_WIDTH, BODY_HEIGHT)
+    draw_layout_box(0, 0, BODY_WIDTH, BODY_HEIGHT)
 
     graphics.set_text_colour(graphics.BRIGHTWHITE)
-    graphics.draw_text(12, 14, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE, "CHIP-8")
-    graphics.draw_text(BODY_WIDTH - 12, 14, 0, graphics.TXJ_RIGHT | graphics.TXJ_MIDDLE, rom_label)
+    draw_layout_text(12, 14, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE, "CHIP-8")
+    draw_layout_text(BODY_WIDTH - 12, 14, 0, graphics.TXJ_RIGHT | graphics.TXJ_MIDDLE, rom_label)
 
     graphics.set_pen_colour(graphics.BRIGHTGREEN)
     graphics.set_brush_colour(graphics.BLACK)
-    graphics.draw_box(SCREEN_LEFT, SCREEN_TOP, SCREEN_RIGHT, SCREEN_BOTTOM)
+    draw_layout_box(SCREEN_LEFT, SCREEN_TOP, SCREEN_RIGHT, SCREEN_BOTTOM)
     draw_framebuffer()
 
     if not running then
         graphics.set_text_colour(graphics.BRIGHTGREEN)
         graphics.set_text_size(14)
-        graphics.draw_text(math.floor((SCREEN_LEFT + SCREEN_RIGHT) / 2),
-                           math.floor((SCREEN_TOP + SCREEN_BOTTOM) / 2), 0,
-                           graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE,
-                           fault_message == nil and "STOPPED" or "ROM ERROR")
+        draw_layout_text(math.floor((SCREEN_LEFT + SCREEN_RIGHT) / 2),
+                         math.floor((SCREEN_TOP + SCREEN_BOTTOM) / 2), 0,
+                         graphics.TXJ_CENTRE | graphics.TXJ_MIDDLE,
+                         fault_message == nil and "STOPPED" or "ROM ERROR")
     end
 
     graphics.set_text_size(10)
     graphics.set_text_colour(graphics.BRIGHTWHITE)
     local state = running and "RUN" or (fault_message == nil and "STOP" or "ERROR")
     local pc = vm == nil and Chip8.PROGRAM_ADDRESS or vm.pc
-    graphics.draw_text(SCREEN_LEFT, 144, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE,
-                       string.format("%s  PC:%04X  %d Hz  %d ips", state, pc, TIMER_HZ, CPU_HZ))
+    draw_layout_text(SCREEN_LEFT, 144, 0, graphics.TXJ_LEFT | graphics.TXJ_MIDDLE,
+                     string.format("%s  PC:%04X  %d Hz  %d ips", state, pc, TIMER_HZ, CPU_HZ))
 
     for index, key in ipairs(keys) do
         draw_key(index, key)
@@ -322,9 +337,10 @@ function device_graphics_actuate(key, x, y, flags)
         return false
     end
 
+    local layout_y = proteus_y(y)
     for index, keypad_key in ipairs(keys) do
         local left, top, right, bottom = key_bounds(index)
-        if x >= left and x <= right and y >= top and y <= bottom then
+        if x >= left and x <= right and layout_y >= top and layout_y <= bottom then
             return press_key(keypad_key.value)
         end
     end

--- a/model/tests/fixtures/chip8_core_test.lua
+++ b/model/tests/fixtures/chip8_core_test.lua
@@ -250,7 +250,9 @@ end
 local function test_device_adapter()
     local draw_count = 0
     local repaint_count = 0
+    local drawn_boxes = {}
     local drawn_text = {}
+    local drawn_text_y = {}
     local callbacks = {}
     local errors = {}
     local messages = {}
@@ -291,12 +293,14 @@ local function test_device_adapter()
         set_pen_colour = function() end,
         set_brush_colour = function() end,
         set_text_colour = function() end,
-        draw_box = function()
+        draw_box = function(left, bottom, right, top)
             draw_count = draw_count + 1
+            drawn_boxes[#drawn_boxes + 1] = {left = left, bottom = bottom, right = right, top = top}
         end,
-        draw_text = function(_, _, _, _, text)
+        draw_text = function(_, y, _, _, text)
             draw_count = draw_count + 1
             drawn_text[#drawn_text + 1] = text
+            drawn_text_y[text] = y
         end,
         repaint = function()
             repaint_count = repaint_count + 1
@@ -319,9 +323,26 @@ local function test_device_adapter()
           "device did not report the built-in demo")
 
     draw_count = 0
+    drawn_boxes = {}
+    drawn_text_y = {}
     device_graphics_plot(0)
     local empty_display_draw_count = draw_count
     check(empty_display_draw_count >= 20, "device adapter did not draw the console face")
+    check(drawn_boxes[2].bottom == 40 and drawn_boxes[2].top == 136,
+          "device adapter did not convert the screen bounds to Proteus Y-up coordinates")
+    check(drawn_boxes[3].bottom == 112 and drawn_boxes[3].top == 136,
+          "device adapter did not place the first keypad row at the top")
+    check(drawn_boxes[18].bottom == 28 and drawn_boxes[18].top == 52,
+          "device adapter did not place the last keypad row at the bottom")
+    check(drawn_text_y["CHIP-8"] == 152 and drawn_text_y["DEMO"] == 152,
+          "device adapter did not place the title at the top")
+    local status_y
+    for _, text in ipairs(drawn_text) do
+        if text:match("^RUN%s") then
+            status_y = drawn_text_y[text]
+        end
+    end
+    check(status_y == 22, "device adapter did not place the run status at the bottom")
 
     for index = 1, 60 do
         local scheduled = callbacks[index]
@@ -342,7 +363,7 @@ local function test_device_adapter()
           "device did not render its ROM and run status")
 
     local repaint_before_key = repaint_count
-    check(device_graphics_actuate(0, 222, 32, graphics.ACF_LEFT),
+    check(device_graphics_actuate(0, 222, 124, graphics.ACF_LEFT),
           "device adapter did not accept a keypad click")
     check(repaint_count == repaint_before_key + 1, "keypad click did not request a repaint")
     timer_callback(callbacks[61].time, callbacks[61].event_id)


### PR DESCRIPTION
## What changed

- Keep CHIP-8 layout coordinates in the portable top-left/Y-down convention.
- Convert box, text, framebuffer, and mouse-input Y coordinates at the Proteus adapter boundary.
- Document the coordinate-system boundary.
- Extend the CHIP-8 adapter test to verify screen, keypad-row, title, status, and click coordinates.

## Root cause

The CHIP-8 view was laid out for a conventional top-left origin, while the Proteus VSM component surface uses a bottom-left origin. Passing layout Y values directly inverted the display, glyph rows, labels, status line, and keypad.

## Impact

The Proteus display now matches the intended wireframe and mouse hit-testing follows the corrected visual keypad. The CHIP-8 core and layout remain straightforward to reuse in a future ImGui adapter.

## Validation

- `ctest --test-dir build/runtime-logging-test -C Release -R '^chip8_core$' --output-on-failure`
- Full native suite: 20/20 passed.
- `git diff --check`.