### PR TITLE
Request initial CHIP-8 repaint

### DIFF
--- a/examples/chip8/device.lua
+++ b/examples/chip8/device.lua
@@ -272,6 +272,7 @@ function device_graphics_init()
     graphics.set_draw_scale(96)
     graphics.set_pen_width(1)
     graphics.set_text_size(12)
+    graphics.repaint()
 end
 
 function device_graphics_plot(_)

--- a/model/tests/fixtures/chip8_core_test.lua
+++ b/model/tests/fixtures/chip8_core_test.lua
@@ -314,6 +314,7 @@ local function test_device_adapter()
 
     device_init()
     device_graphics_init()
+    check(repaint_count == 1, "graphics initialization did not request the first repaint")
     check(#callbacks == 1 and callbacks[1].time > systime(), "device did not schedule its first timer tick")
     check(#messages == 1 and messages[1]:find("DEMO", 1, true) ~= nil,
           "device did not report the built-in demo")


### PR DESCRIPTION
## Summary

- request a graphics repaint when the CHIP-8 active model finishes graphics initialization
- verify initialization requests exactly one first repaint

## Why

Proteus may not plot the active model until an interaction invalidates the component surface. This makes the CHIP-8 display appear only after clicking it.

## Testing

- `ctest --test-dir build/runtime-logging-test -C Release -R ^chip8_core$ --output-on-failure`
- `ctest --test-dir build/runtime-logging-test -C Release --output-on-failure` (20/20 passed)