### PR TITLE
Terminate CHIP-8 startup log line

### DIFF
--- a/examples/chip8/device.lua
+++ b/examples/chip8/device.lua
@@ -254,7 +254,7 @@ function device_init()
 
     rom_label = label_or_error
     running = true
-    print(string.format("CHIP-8 started: %s (%d bytes, %d instructions/s)", rom_label, #rom, CPU_HZ))
+    print(string.format("CHIP-8 started: %s (%d bytes, %d instructions/s)\n", rom_label, #rom, CPU_HZ))
     set_callback(systime() + next_timer_interval(), TIMER_EVENT)
 end
 


### PR DESCRIPTION
## Summary

Terminate the CHIP-8 startup message explicitly before OpenVSM emits the following runtime log entry.

## Why

The Lua `print` bridge does not add a line ending of its own. Without one, Proteus concatenates `CHIP-8 started` and the subsequent `Device initialization completed` entry on the same line.

## Impact

CHIP-8 startup diagnostics are readable and each runtime log entry begins on its own line.

## Validation

- `ctest --test-dir build/runtime-logging-test -C Release -R ^chip8_core$ --output-on-failure`