### PR TITLE
Normalize CHIP-8 Lua metadata

### DIFF
--- a/examples/chip8/device.txt
+++ b/examples/chip8/device.txt
@@ -32,8 +32,8 @@ NAME=LUA_CHIP8
 {PRIMITIVE=DIGITAL}
 
 {MODDLL=openvsm.DLL}
-{
-LUA=chip8/device.lua}
+
+{LUA=chip8/device.lua}
 
 {ROM=}
 


### PR DESCRIPTION
## Summary

Write the CHIP-8 `LUA` device property as one canonical Proteus metadata field.

## Why

The opening brace was on a separate line, leaving an orphan `{` record and splitting the property across two lines. Keeping `{LUA=chip8/device.lua}` together makes the descriptor unambiguous and consistent with the other fields.

## Impact

The generated device descriptor points at the same script without relying on permissive parsing of malformed metadata.

## Validation

- verified exactly one `{LUA=chip8/device.lua}` field
- verified there is no orphan opening-brace line
- `git diff --check`