### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,188 @@
+name: Release
+
+run-name: Release ${{ inputs.tag }} from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag matching model/VERSION.txt (for example, 0.7)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: openvsm-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Validate, test, package, and publish
+    runs-on: windows-2022
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      BUILD_DIR: build/release
+
+    steps:
+      - name: Check out the selected commit
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate release request
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $expectedRef = "refs/heads/$env:DEFAULT_BRANCH"
+          if ($env:GITHUB_REF -cne $expectedRef) {
+              throw "Releases must run from the default branch ($expectedRef), not $env:GITHUB_REF."
+          }
+
+          $version = (Get-Content "model/VERSION.txt" -Raw).Trim()
+          $expectedTag = $version
+          if ($env:RELEASE_TAG -cne $expectedTag) {
+              throw "Tag '$env:RELEASE_TAG' does not match model/VERSION.txt; expected '$expectedTag'."
+          }
+
+          $remoteTag = git ls-remote --tags origin "refs/tags/$env:RELEASE_TAG"
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to inspect existing tags."
+          }
+          if ($remoteTag) {
+              throw "Tag '$env:RELEASE_TAG' already exists."
+          }
+
+          "OPENVSM_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install clang-format 21
+        run: |
+          $ErrorActionPreference = "Stop"
+          python -m pip install --disable-pip-version-check clang-format==21.1.0
+          if ($LASTEXITCODE -ne 0) {
+              throw "Failed to install clang-format 21.1.0."
+          }
+
+          $scriptsDirectory = python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+          $scriptsDirectory | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Check source formatting
+        run: |
+          $ErrorActionPreference = "Stop"
+          $formatterVersion = clang-format --version
+          if ($formatterVersion -notmatch "version 21\.1\.0") {
+              throw "Expected clang-format 21.1.0, got: $formatterVersion"
+          }
+          ./tools/format.ps1 -Check
+
+      - name: Locate Inno Setup
+        run: |
+          $ErrorActionPreference = "Stop"
+          $compiler = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+          if ($null -ne $compiler) {
+              $compilerPath = $compiler.Source
+          }
+          else {
+              $compilerPath = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          }
+
+          if (-not (Test-Path -LiteralPath $compilerPath -PathType Leaf)) {
+              throw "Inno Setup compiler was not found."
+          }
+
+          "INNO_SETUP_COMPILER=$compilerPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Configure Win32 Release build
+        run: |
+          cmake -S . -B $env:BUILD_DIR -A Win32 `
+              -DBUILD_TESTS=ON `
+              -DDLL_WITH_INSTALLER=ON `
+              "-DINNO_SETUP_COMPILER=$env:INNO_SETUP_COMPILER"
+
+      - name: Build Release and tests
+        run: cmake --build $env:BUILD_DIR --config Release --parallel
+
+      - name: Run all tests
+        run: ctest --test-dir $env:BUILD_DIR -C Release --output-on-failure
+
+      - name: Build installer
+        run: cmake --build $env:BUILD_DIR --config Release --target BuildInstaller --parallel
+
+      - name: Verify release artifacts
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installerPath = Join-Path $env:GITHUB_WORKSPACE `
+              "$env:BUILD_DIR\installer\openvsm-$env:OPENVSM_VERSION-setup.exe"
+          $dllPath = Join-Path $env:GITHUB_WORKSPACE "$env:BUILD_DIR\bin\Release\openvsm.dll"
+
+          foreach ($artifact in @($installerPath, $dllPath)) {
+              if (-not (Test-Path -LiteralPath $artifact -PathType Leaf)) {
+                  throw "Expected release artifact was not created: $artifact"
+              }
+          }
+
+          $installerVersion = (Get-Item -LiteralPath $installerPath).VersionInfo.ProductVersion.Trim()
+          if ($installerVersion -cne $env:OPENVSM_VERSION) {
+              throw "Installer version '$installerVersion' does not match '$env:OPENVSM_VERSION'."
+          }
+
+          $versionParts = @($env:OPENVSM_VERSION.Split('.'))
+          if ($versionParts.Count -gt 4) {
+              throw "model/VERSION.txt has more than four numeric components."
+          }
+          while ($versionParts.Count -lt 4) {
+              $versionParts += "0"
+          }
+          $expectedDllVersion = $versionParts -join "."
+          $dllVersion = (Get-Item -LiteralPath $dllPath).VersionInfo.ProductVersion.Trim()
+          if ($dllVersion -cne $expectedDllVersion) {
+              throw "DLL version '$dllVersion' does not match '$expectedDllVersion'."
+          }
+
+          $installerHash = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash
+          "INSTALLER_PATH=$installerPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "INSTALLER_SHA256=$installerHash" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          @(
+              "### OpenVSM $env:OPENVSM_VERSION release candidate",
+              "",
+              "- Tag: $env:RELEASE_TAG",
+              "- Commit: $env:GITHUB_SHA",
+              "- Installer SHA-256: ``$installerHash``"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Create tag and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $releaseNotes = @"
+          Automated Win32 release built and tested from commit $env:GITHUB_SHA.
+
+          - clang-format 21 check passed
+          - Win32 Release build passed
+          - all CTest tests passed
+          - installer SHA-256: $env:INSTALLER_SHA256
+          "@
+
+          gh release create $env:RELEASE_TAG `
+              "$env:INSTALLER_PATH#OpenVSM $env:OPENVSM_VERSION installer" `
+              --target $env:GITHUB_SHA `
+              --title "OpenVSM $env:OPENVSM_VERSION" `
+              --notes $releaseNotes `
+              --generate-notes `
+              --fail-on-no-commits `
+              --latest
+          if ($LASTEXITCODE -ne 0) {
+              throw "GitHub release creation failed."
+          }

--- a/externals/installer/README.md
+++ b/externals/installer/README.md
@@ -40,3 +40,23 @@ install model DLLs into the OpenVSM application directory.
 Lua examples are copied below `{app}\LuaScripts` with their repository
 subdirectories preserved. Existing or user-modified example files are never
 overwritten or removed during uninstall.
+
+## Automated GitHub release
+
+The `Release` workflow publishes a tested installer from the default branch:
+
+1. Update `model/VERSION.txt` and merge the release commit into the default
+   branch.
+2. Open **Actions**, select **Release**, and choose **Run workflow**.
+3. Leave the branch set to the default branch and enter the exact version as
+   the tag, for example `0.7`.
+
+The workflow rejects tags that already exist or do not match
+`model/VERSION.txt`. It checks clang-format 21, builds the Win32 Release
+configuration, runs the complete CTest suite, builds the installer, and
+verifies the installer and DLL versions. Only after every check succeeds does
+it create the tag and published GitHub release, attach the installer, and
+generate release notes from merged pull requests.
+
+The automated workflow produces unsigned binaries. Local signed builds remain
+available through `OPENVSM_SIGN_CERTIFICATE_SHA1` as described above.


### PR DESCRIPTION
## Summary

- add a manual `Release` workflow with a required release-tag input
- validate the tag against `model/VERSION.txt`, the default branch, and existing remote tags
- run clang-format 21, a clean Win32 Release build, and all CTest tests
- build and verify the 0.7 installer and DLL before publishing anything
- create the tag and published GitHub release together, attach the installer, and generate categorized release notes
- document how to run the workflow and its unsigned-binary behavior

## Safety

The workflow receives the tag through an environment variable, grants only `contents: write`, serializes release runs, and performs tag/release creation as the final step. A failed format, build, test, package, or verification step leaves no release tag behind.

## Validation

- actionlint 1.7.12: passed
- clang-format 21.1.0: 50 files passed
- clean Visual Studio 2022 Win32 Release build: passed
- CTest: 20/20 passed
- Inno Setup installer build: passed
- installer version `0.7`, DLL version `0.7.0.0`, and SHA-256 verification: passed