### PR TITLE
Simplify README and add user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,156 +1,53 @@
-# OpenVSM is Lua bindings for Proteus 7/8 CAD
-[![Release][release-image]][releases] [![Wiki][wiki-img]][wiki]
+# OpenVSM
 
+OpenVSM lets [Proteus VSM](https://www.labcenter.com/) components implement
+their simulation behavior and optional schematic graphics in Lua. One 32-bit
+`openvsm.dll` can serve many device types and instances; every component loads
+its configured script into an isolated Lua state.
 
-[release-image]: https://img.shields.io/badge/release-0.6.213-blue.svg?style=flat
-[releases]: https://github.com/Pugnator/openvsm/releases
-[wiki-img]: https://img.shields.io/badge/docs-Wiki-blue.svg
-[wiki]: https://github.com/Pugnator/openvsm/wiki
+[Download a release](https://github.com/Pugnator/openvsm/releases) ·
+[Read the user guide](docs/USER-GUIDE.md) ·
+[Browse the documentation](docs/README.md) ·
+[Report an issue](https://github.com/Pugnator/openvsm/issues)
 
+## A minimal model
 
-Tested on Proteus 8.9
-
-Please report all issues you face in order to make this tool better
-
-![Lua logo](http://www.lua.org/images/powered-by-lua.gif)
-
-Powered by Lua http://www.lua.org/
-
-Documentation can be found at http://pugnator.github.io/openvsm
-
-The executable Lua compatibility surface and v0.7 migration notes are listed in
-[`docs/V0.7-LUA-COMPATIBILITY.md`](docs/V0.7-LUA-COMPATIBILITY.md).
-
-The v0.7 architecture and generated C++ reference are described in
-[`docs/DEVELOPER-GUIDE.md`](docs/DEVELOPER-GUIDE.md).
-
-CPU-like models can implement the SDK's Virtual Debug Monitor protocol through
-the [`Lua VDM target bridge`](docs/VDM-LUA-API.md).
-
-Any model can expose bounded state to external tools with the
-[`VDM third-party control profile`](docs/THIRD-PARTY-CONTROL.md).
-
-Active displays and animated components can use the
-[`Lua graphics and animation API`](docs/GRAPHICS-LUA-API.md).
-
-Prebuilt DLL and symbols or installer are in [Release](https://github.com/Pugnator/openvsm/releases) section
-
-The v0.7 native model is written in C++20 and currently builds with 32-bit MSVC.
-
-  - You don't need to recompile anything - one DLL for all models in Lua
-  - You can create your model as a standalone DLL or use DLL and Lua script together while prototyping
-  - You can write your own Lua scripts that will be precompiled and built-in into DLL
-  - Function prototypes have similar syntax in C and Lua API
-  - Designed with hope to make simulation as simple as possible for electronics enthusiasts
-
-
-Visit 'examples' directory for sample project files. There is no tutorial yet but I'm working on it
-
-Please kindly send all your remarks and ideas to my mail [o o kami (at) ma il.ru] or submit a bug or feature request
-
-There are plenty to do!
-
-Generally you need to compile DLL from the sources only if you want to include custom scripts.
-
-## Native buses
-
-Lua models declare native Proteus buses alongside `device_pins`:
+This script implements a two-input NAND gate. The names in `device_pins` match
+the terminal names on the Proteus component.
 
 ```lua
-device_buses = {
-    {name = "D", base = 0, width = 8, on_time = 100000,
-     off_time = 120000, tristate_time = 50000}
+device_pins = {
+    {name = "A", on_time = 100000, off_time = 100000},
+    {name = "B", on_time = 100000, off_time = 100000},
+    {name = "Q", on_time = 100000, off_time = 100000}
 }
-```
 
-Widths from 1 through 32 bits are supported. Each declaration creates a global
-object (for example `D`) with `set`/`drive`, `tristate`, `drivebit`, `get`,
-`getdrive`, `getbitstate`, `settiming`, and `setstates` methods. Bit indices are
-zero-based, and drive values must fit the declared width. The optional
-`on_state`, `off_state`, `tristate_state`, and `required` fields configure the
-corresponding SDK behavior. Call methods with Lua's object syntax, such as
-`D:drive(0x5a)` or `D:drivebit(0, SHI)`.
-
-Pin objects support `pin:onchange(function)` and `pin:onstate(state, function)`.
-Bus objects similarly support `bus:onchange(function)` and
-`bus:onvalue(value, function)`. A callback receives simulation time, simulation
-mode, and the new pin state or bus value. It runs only after the registered
-object changes; a callback that raises an error is disabled without affecting
-the other callbacks.
-
-```lua
-function device_init()
-    A:onstate(SHI, function(time, mode, state)
-        print("A became high", time, mode, state)
-    end)
+function device_simulate()
+    Q:set(1 - (A:get() * B:get()))
 end
 ```
 
-# Installation
---------------
+Install OpenVSM, configure the component with `MODDLL=openvsm.DLL` and
+`LUA=device.lua`, then place the script beside the Proteus project. The
+[user guide](docs/USER-GUIDE.md) covers device properties, script lookup,
+pins, buses, callbacks, graphics, and troubleshooting.
 
-  - Download OPenVSM MSI installer from `release` section
-  - Run installer and install it
-  - Visit `exmples` for some example projects  
+## Examples
 
-## How to build
+| Example | What it demonstrates |
+| --- | --- |
+| [NAND](examples/NAND) | The smallest useful digital model |
+| [Active display](examples/graphics) | Lua drawing and mouse input on the schematic |
+| [CHIP-8](examples/chip8) | A complete VM with a display, keypad, timers, and per-instance ROM selection |
+| [Optional modules](model/lua/modules) | UART and third-party control helpers |
 
-### Requirements
+## Documentation
 
-- Visual Studio 2022 with the **Desktop development with C++** workload and
-  Win32 build tools;
-- CMake 3.21 or newer (CMake 4.x is supported);
-- the Proteus VSM SDK headers supplied with your Proteus installation.
+- [Using OpenVSM](docs/USER-GUIDE.md)
+- [Building from source](docs/BUILDING.md)
+- [Lua graphics API](docs/GRAPHICS-LUA-API.md)
+- [Lua v0.7 compatibility](docs/V0.7-LUA-COMPATIBILITY.md)
+- [Developer guide](docs/DEVELOPER-GUIDE.md)
 
-CMake is the only supported project build entry point. Makefiles inside
-`externals/Lua` belong to that upstream submodule and are not used by OpenVSM.
-
-### Checkout
-
-Clone with the Lua and TinyLog submodules:
-
-```powershell
-git clone --recurse-submodules https://github.com/Pugnator/openvsm.git
-cd openvsm
-```
-
-For an existing checkout, initialize them with:
-
-```powershell
-git submodule update --init --recursive
-```
-
-### Proteus SDK
-
-Create `externals/sdk` and copy the VSM SDK headers into it. At minimum, the
-directory must contain `vsm.hpp`; model-specific VDM headers can be placed next
-to it. The directory is ignored by Git because the SDK is distributed with
-Proteus rather than this project.
-
-### Configure and build
-
-The checked-in preset selects Visual Studio 2022 and its 32-bit platform:
-
-```powershell
-cmake --preset vs2022-win32
-cmake --build --preset debug
-cmake --build --preset release
-```
-
-For a manual Visual Studio configuration, select the same target with
-`-A Win32`; MSVC does not use the GCC `-m32` option.
-
-Build outputs are written below `build/vs2022-win32/bin/<configuration>`.
-
-Each Proteus model selects its script with the component's `LUA` string property,
-for example `LUA=device.lua`. Relative values are resolved beside the Proteus
-project first, then beneath `LUAVSM`; this lets a project-local script override
-the installed default for that model. Absolute paths are used directly. Paths
-may contain spaces and `LUAVSM` does not need a trailing slash. A missing
-property or readable script keeps that model out of simulation, with every
-searched path recorded in `log.txt`.
-
-# License
-----
-
-GPL 2
+OpenVSM v0.7 uses Lua 5.4 and builds as a 32-bit Windows DLL with C++20 and
+MSVC. It is licensed under [GPL-2.0-or-later](LICENSE).

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,0 +1,83 @@
+# Building OpenVSM
+
+Most users should install a binary from
+[GitHub releases](https://github.com/Pugnator/openvsm/releases). Build from
+source when changing the runtime, running its native tests, or producing an
+installer.
+
+## Requirements
+
+- Visual Studio 2022 with the **Desktop development with C++** workload and
+  Win32 build tools
+- CMake 3.21 or newer
+- the Proteus VSM SDK headers supplied with Proteus
+
+The v0.7 runtime is C++20 and supports MSVC Win32 builds. CMake is the supported
+build entry point; makefiles inside the Lua submodule belong to upstream Lua
+and are not used by OpenVSM.
+
+## Checkout and SDK
+
+Clone the repository with its submodules:
+
+```powershell
+git clone --recurse-submodules https://github.com/Pugnator/openvsm.git
+cd openvsm
+```
+
+For an existing checkout:
+
+```powershell
+git submodule update --init --recursive
+```
+
+Create `externals/sdk` and copy the VSM SDK headers into it. At minimum it must
+contain `vsm.hpp`; model-specific VDM headers may be placed beside it. The SDK
+directory is ignored because those headers are distributed with Proteus, not
+with OpenVSM.
+
+## Configure, build, and test
+
+The checked-in preset selects Visual Studio 2022 and the 32-bit platform:
+
+```powershell
+cmake --preset vs2022-win32 -DBUILD_TESTS=ON
+cmake --build --preset debug
+ctest --test-dir build/vs2022-win32 -C Debug --output-on-failure
+```
+
+Build the release configuration with:
+
+```powershell
+cmake --build --preset release
+```
+
+Outputs are written below `build/vs2022-win32/bin/<configuration>`. For a
+manual Visual Studio configuration, select `-A Win32`; MSVC does not use the
+GCC `-m32` option.
+
+## Build the installer
+
+Install Inno Setup and make `ISCC.exe` available on `PATH`, then run:
+
+```powershell
+cmake -S . -B .build/installer -A Win32 -DDLL_WITH_INSTALLER=ON
+cmake --build .build/installer --config Release --target BuildInstaller
+```
+
+The installer is written below `.build/installer/installer`. Signing options
+and installation behavior are documented in the
+[installer README](../externals/installer/README.md).
+
+## Build the developer reference
+
+Install Doxygen, then enable its opt-in target:
+
+```powershell
+cmake -S . -B .build/docs -A Win32 -DBUILD_DOCS=ON
+cmake --build .build/docs --target openvsm-docs
+```
+
+Open `.build/docs/docs/html/index.html`. See the
+[developer guide](DEVELOPER-GUIDE.md) before changing the native API and use
+the repository's [code-style instructions](CODE-STYLE.md) for C++ changes.

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -24,8 +24,8 @@ The runtime path has four layers:
 instance currently being simulated. It does not own the registered devices.
 
 The proprietary Labcenter SDK is deliberately not copied into the repository.
-The build expects its headers under `externals/sdk`; see the root README for the
-checkout and build procedure.
+The build expects its headers under `externals/sdk`; see
+[`BUILDING.md`](BUILDING.md) for the checkout and build procedure.
 
 ## Model lifecycle
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# OpenVSM documentation
+
+Start with the [user guide](USER-GUIDE.md) to install OpenVSM and create a Lua
+device. The other documents cover specialized APIs and project development.
+
+## Using OpenVSM
+
+- [User guide](USER-GUIDE.md): installation, component setup, Lua models,
+  script lookup, and troubleshooting.
+- [Lua graphics and animation API](GRAPHICS-LUA-API.md): active schematic
+  displays, drawing, repainting, and input.
+- [Lua VDM target bridge](VDM-LUA-API.md): expose a CPU-like model to the
+  Proteus Virtual Debug Monitor.
+- [Third-party control](THIRD-PARTY-CONTROL.md): expose bounded model state to
+  external tools through VDM.
+- [Lua v0.7 compatibility](V0.7-LUA-COMPATIBILITY.md): supported legacy names
+  and migration rules.
+
+## Developing OpenVSM
+
+- [Building from source](BUILDING.md): prerequisites, CMake, tests, installer,
+  and generated documentation.
+- [Developer guide](DEVELOPER-GUIDE.md): runtime architecture, ownership, and
+  API contribution guidance.
+- [Code style](CODE-STYLE.md): formatting commands and third-party exclusions.
+
+Runnable scripts are collected in the repository's [examples](../examples)
+directory.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,0 +1,245 @@
+# Using OpenVSM
+
+OpenVSM is a shared model DLL for Proteus VSM. A schematic component selects a
+Lua script, and that script declares the component's pins or buses and handles
+simulation events. Active components may also draw their own schematic face
+and receive mouse input.
+
+OpenVSM is currently a 32-bit Windows model using Lua 5.4. Each component
+instance owns a separate Lua state, so devices can share `openvsm.dll` while
+using different scripts, parameters, and runtime state.
+
+## Install OpenVSM
+
+Download and run the latest `.exe` installer from the
+[GitHub releases](https://github.com/Pugnator/openvsm/releases) page. The
+installer locates the Proteus Models directory and installs `openvsm.dll`
+there. It also installs the example scripts into an OpenVSM `LuaScripts`
+directory and creates the machine-wide `LUAVSM` environment variable when one
+does not already exist.
+
+Restart Proteus after installing or changing `LUAVSM` so it inherits the
+updated environment.
+
+## Create a digital device
+
+The exact library-editor screens differ between Proteus versions, but the
+model needs these component properties:
+
+| Property | Value | Purpose |
+| --- | --- | --- |
+| `PRIMITIVE` | `DIGITAL` | Selects the Proteus digital simulation interface |
+| `MODDLL` | `openvsm.DLL` | Loads the shared OpenVSM model |
+| `LUA` | For example, `device.lua` | Selects the script for this component instance |
+
+Create terminals whose names match the Lua pin declarations. A minimal NAND
+model saved as `device.lua` is:
+
+```lua
+device_pins = {
+    {name = "A", on_time = 100000, off_time = 100000},
+    {name = "B", on_time = 100000, off_time = 100000},
+    {name = "Q", on_time = 100000, off_time = 100000}
+}
+
+function device_simulate()
+    Q:set(1 - (A:get() * B:get()))
+end
+```
+
+Place `device.lua` beside the Proteus project, add the configured part to the
+schematic, and start the simulation. The complete small example is in
+[`examples/NAND`](../examples/NAND).
+
+## How scripts are found
+
+The `LUA` property belongs to the component instance and supports either form:
+
+- An absolute path is used directly.
+- A relative path is searched beside the Proteus project first, then below
+  the directory in `LUAVSM`.
+
+For example, `LUA=chip8/device.lua` can load a project-local copy or fall back
+to `%LUAVSM%\chip8\device.lua`. Project-first lookup makes it possible to edit
+or override a model without replacing the installed example. Paths may contain
+spaces, and `LUAVSM` does not need a trailing slash.
+
+If a script cannot be loaded, `log.txt` records the configured value and every
+path that OpenVSM searched.
+
+## Model lifecycle
+
+A script may define these functions:
+
+| Function | When it runs |
+| --- | --- |
+| `device_init()` | Once, after the script's pins and buses have been registered |
+| `device_simulate()` | Whenever Proteus activates the digital model for simulation |
+| `timer_callback(time, event_id)` | When a callback scheduled with `set_callback` is due |
+
+Only define the callbacks the model needs. Callback errors are logged and the
+Lua stack is restored. A failing `device_simulate` or pin/bus object callback
+is disabled to prevent the same error from recurring on every host event.
+
+Simulation times are integer picoseconds. The constants `NSEC`, `USEC`, `MSEC`,
+and `SEC` make scheduling readable:
+
+```lua
+local TICK = 1
+
+function device_init()
+    set_callback(systime() + MSEC, TICK)
+end
+
+function timer_callback(time, event_id)
+    if event_id == TICK then
+        -- Update the device here.
+        set_callback(time + MSEC, TICK)
+    end
+end
+```
+
+## Pins
+
+Every model must declare `device_pins`, even when it is an empty table. Each
+entry creates a global object with the same name. `name` identifies the Proteus
+terminal; `on_time` and `off_time` are optional transition delays in
+picoseconds and default to zero.
+
+Common operations are:
+
+```lua
+local level = A:get() -- 0 for low, 1 for high
+Q:set(1)              -- drive high
+Q:lo()                -- drive low
+Q:invert()            -- invert the current drive
+Q:setstate(FLT)       -- drive a Proteus logic state directly
+```
+
+The API also provides state queries such as `ishigh()`, `islow()`, `isedge()`,
+`isposedge()`, `isnegedge()`, `isfloating()`, and `iscontention()`.
+
+Register object callbacks from `device_init` when a model should respond only
+to changes:
+
+```lua
+function device_init()
+    A:onchange(function(time, mode, state)
+        info("A changed to " .. state_to_string(state))
+    end)
+
+    B:onstate(SHI, function(time, mode, state)
+        info("B became strongly high")
+    end)
+end
+```
+
+## Buses
+
+Declare a native Proteus bus in `device_buses`. Widths from 1 through 32 bits
+are supported, and bit indices are zero-based.
+
+```lua
+device_buses = {
+    {
+        name = "D",
+        base = 0,
+        width = 8,
+        on_time = 100000,
+        off_time = 120000,
+        tristate_time = 50000
+    }
+}
+
+function device_init()
+    D:onvalue(0x55, function(time, mode, value)
+        info("D received 0x55")
+    end)
+end
+
+function device_simulate()
+    D:drive(0x5a)
+end
+```
+
+Bus objects provide `set`/`drive`, `tristate`, `drivebit`, `get`, `getdrive`,
+`getbitstate`, `settiming`, and `setstates`. Use `onchange(function)` for every
+value change or `onvalue(value, function)` for one value. Optional declaration
+fields include `on_state`, `off_state`, `tristate_state`, and `required`.
+
+## Component parameters and logging
+
+Use these functions to read values from the component instance:
+
+- `get_string_param(name)`
+- `get_num_param(name)`
+- `get_bool_param(name)`
+- `get_init_param(name)`
+- `get_hex_param(name)`
+
+This is how multiple instances of one device can select different ROMs or
+settings while sharing the same DLL and Lua source.
+
+`info(text)`, `message(text)`, `warning(text)`, and `vsm_error(text)` forward
+messages to the corresponding Proteus instance service. OpenVSM's runtime
+diagnostics are appended to `log.txt` in the Proteus process working directory
+when that location is writable. The log identifies the component, selected
+script, pin count, initialization result, and callback errors.
+
+## Active graphics
+
+A device that draws or accepts input on the schematic needs the normal digital
+properties plus active-component metadata:
+
+- use the active name stem `OPENVSM`;
+- configure one state and enable DLL linking;
+- create or reuse the active sprite named `OPENVSM_0`;
+- keep the device-specific `LUA` property on the component.
+
+The equivalent active declaration in a text device description is:
+
+```text
+{ACTIVE=OPENVSM,1,DLL}
+```
+
+Proteus derives the active DLL name from the active stem. A stem such as the
+part name `LUA_CHIP8` would make it search for `LUA_CHIP8.dll` instead of the
+shared `openvsm.dll`.
+
+The Lua script can implement `device_graphics_init`, `device_graphics_plot`,
+`device_graphics_animate`, and `device_graphics_actuate`. Call
+`graphics.repaint()` after initializing or changing visible state. See the
+[graphics API](GRAPHICS-LUA-API.md), the minimal
+[active display](../examples/graphics), and the complete
+[CHIP-8 console](../examples/chip8).
+
+## Troubleshooting
+
+### The model does not start
+
+Open `log.txt` and look for `Loading model script`. A missing script error lists
+every searched path. Check the component's `LUA` property, the Proteus project
+location, and `LUAVSM`.
+
+### `log.txt` is empty or missing
+
+OpenVSM writes the file in the Proteus process working directory. If that
+directory is not writable, file logging is disabled. Confirm that the installed
+DLL is the expected build and that the process can create `log.txt` there.
+
+### Pins are not registered
+
+Pin declaration names must match the component terminal names exactly. The log
+reports the number of pins registered during setup.
+
+### An active device starts but remains blank
+
+Confirm that Proteus created an active model, not only a digital model. Check
+the `OPENVSM` active stem, the `OPENVSM_0` sprite, DLL linking, and the graphics
+callbacks. The initialization callback should request a repaint after setting
+its drawing state.
+
+### Lua changes are not visible
+
+Stop and restart the Proteus simulation so the component creates a new Lua
+state and reloads its script.

--- a/docs/V0.7-LUA-COMPATIBILITY.md
+++ b/docs/V0.7-LUA-COMPATIBILITY.md
@@ -35,7 +35,7 @@ Status meanings:
 | `get_init_param(name)` | **Supported** | Uses `IINSTANCE::getinitval`. |
 | `get_hex_param(name)` | **Supported** | Uses `IINSTANCE::gethexval`. |
 | `systime()` | **Supported** | Returns the current absolute simulation time in picoseconds. |
-| `set_callback(time, event_id)` | **Supported** | Schedules the model through `IDSIMCKT::setcallback`; dispatch is tracked by #48. |
+| `set_callback(time, event_id)` | **Supported** | Schedules the model through `IDSIMCKT::setcallback`; the event is delivered to `timer_callback(time, event_id)`. |
 | `set_bus`, `get_bus` | **Deliberately removed** | Use declarative `device_buses` and native bus objects from #54. Compatibility stubs explain the migration. |
 | `create_debug_popup`, `create_memory_popup`, `create_source_popup`, `create_status_popup`, `create_var_popup` | **Proteus-host-only** | Compatibility stubs raise explicit errors. The pointer-heavy UI API is not part of portable v0.7 models. |
 | `delete_popup`, `set_memory_popup`, `repaint_memory_popup`, `print_to_debug_popup`, `dump_to_debug_popup`, `add_source_file` | **Proteus-host-only** | Compatibility stubs raise explicit errors for the same reason. |
@@ -45,9 +45,9 @@ Status meanings:
 | Surface | v0.7 status | Notes |
 | --- | --- | --- |
 | Pin objects | **Supported** | Registered from `device_pins`; timing correction is tracked by #44. |
-| Native bus objects | **Planned** | Implemented by #54; legacy table-wide `set_bus`/`get_bus` are not restored. |
-| `device_init`, `device_simulate`, `timer_callback` | **Planned** | Stack safety and dispatch are tracked by #48 and #49. |
-| Pin/bus event objects | **Planned** | Tracked by #18. |
+| Native bus objects | **Supported** | Declared through `device_buses`; legacy table-wide `set_bus`/`get_bus` are not restored. |
+| `device_init`, `device_simulate`, `timer_callback` | **Supported** | Lifecycle and scheduled callbacks use protected, stack-balanced Lua calls. |
+| Pin/bus event objects | **Supported** | Pins provide `onchange`/`onstate`; buses provide `onchange`/`onvalue`. |
 | Virtual Debug Monitor | **Supported** | CPU-like models can implement `device_vdm_command` and optional loader/disassembler callbacks; see `VDM-LUA-API.md`. |
 | Precompiled device scripts | **Planned** | The CMake bytecode path is retained, but the old C module loader was incompatible. |
 | `uart` module | **Supported** | Shipped as ordinary Lua source under `model/lua/modules`; uses the v0.7 callback API and initializes the line idle-high. |


### PR DESCRIPTION
## Summary

- replace the long, stale root README with a concise project overview, minimal NAND model, examples, and documentation links
- add a practical user guide covering installation, Proteus properties, script lookup, lifecycle callbacks, pins, buses, parameters, logging, active graphics, and troubleshooting
- add a documentation index and a separate CMake build guide
- update the v0.7 compatibility table to reflect implemented buses, lifecycle hooks, timers, and object callbacks

## Validation

- validated all local Markdown links in the changed documentation
- checked every changed document for balanced code fences
- ran `git diff --check`

Documentation-only change; native tests were not rerun.