### PR TITLE
Initialize submodules in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Validate release request
         env:


### PR DESCRIPTION
## Summary

- initialize Git submodules recursively during the release workflow checkout
- make the bundled Lua and TinyLog CMake projects available before configuration

## Root cause

Release run 31970936794 checked out only the main repository. CMake then failed
because `externals/Lua` and `model/cpp/log` did not contain their submodule
contents. All build, test, installer, and publishing steps were skipped.

## Impact

The next release run can configure the Win32 build instead of failing on
missing submodule `CMakeLists.txt` files. The failed run did not create a tag or
release.

## Validation

- actionlint 1.7.12: passed
- `git diff --check`: passed
